### PR TITLE
ESExtractor: dont use the keywork frame but packet

### DIFF
--- a/lib/esextractor.cpp
+++ b/lib/esextractor.cpp
@@ -59,7 +59,7 @@ ESExtractor::codec_name ()
 }
 
 int
-ESExtractor::frameCount ()
+ESExtractor::packetCount ()
 {
   if (m_stream)
     return m_stream->frameCount ();
@@ -76,7 +76,7 @@ ESExtractor::currentPacket ()
   return nullptr;
 }
 
-ESEResult ESExtractor::processToNextFrame ()
+ESEResult ESExtractor::processToNextPacket ()
 {
   if (m_stream)
     return m_stream->processToNextFrame ();
@@ -115,10 +115,10 @@ es_extractor_new (const char *uri, const char *options)
 }
 
 ESEResult
-es_extractor_read_frame (ESExtractor * extractor, ESEPacket ** packet)
+es_extractor_read_packet (ESExtractor * extractor, ESEPacket ** packet)
 {
   ESEResult res = ESE_RESULT_NEW_PACKET;
-  res = extractor->processToNextFrame ();
+  res = extractor->processToNextPacket ();
   if(res <  ESE_RESULT_EOS)
     *packet = extractor->currentPacket ();
   else
@@ -140,9 +140,9 @@ es_extractor_video_codec_name (ESExtractor * extractor)
 }
 
 int
-es_extractor_frame_count (ESExtractor * extractor)
+es_extractor_packet_count (ESExtractor * extractor)
 {
-  return extractor->frameCount ();
+  return extractor->packetCount ();
 }
 
 void

--- a/lib/esextractor.h
+++ b/lib/esextractor.h
@@ -42,15 +42,15 @@ public:
   bool prepare(const char *uri, const char* options);
   /// @brief This method will build the next frame (NAL or AU) available.
   /// @return
-  ESEResult processToNextFrame();
+  ESEResult processToNextPacket();
   ESEVideoCodec codec();
   const char* codec_name();
 
   /// @brief Reset the extractor state
   ESEPacket* currentPacket();
-  /// @brief Returns the frame count.
+  /// @brief Returns the packet count.
   /// @return
-  int frameCount();
+  int packetCount();
 
   bool openFile (const char *uri);
 
@@ -68,7 +68,7 @@ ES_EXTRACTOR_API
 ESExtractor * es_extractor_new (const char * uri, const char* options);
 
 ES_EXTRACTOR_API
-ESEResult es_extractor_read_frame (ESExtractor * demuxer, ESEPacket ** pkt);
+ESEResult es_extractor_read_packet (ESExtractor * demuxer, ESEPacket ** pkt);
 
 ES_EXTRACTOR_API
 void es_extractor_clear_packet (ESEPacket * pkt);
@@ -80,7 +80,7 @@ ES_EXTRACTOR_API
 const char* es_extractor_video_codec_name(ESExtractor * extractor);
 
 ES_EXTRACTOR_API
-int es_extractor_frame_count (ESExtractor * extractor);
+int es_extractor_packet_count (ESExtractor * extractor);
 
 ES_EXTRACTOR_API
 void es_extractor_teardown (ESExtractor * demuxer);

--- a/tests/testese.cpp
+++ b/tests/testese.cpp
@@ -25,8 +25,8 @@
 static void
 dumpPacket (ESExtractor * esextractor, ESEPacket* pkt)
 {
-  const char *frame_type_name = es_extractor_video_codec_name (esextractor);
-  DBG ("Got a %s frame of size %d pts=%lld", frame_type_name, pkt->data_size, pkt->pts);
+  const char *packet_type_name = es_extractor_video_codec_name (esextractor);
+  DBG ("Got a %s packet of size %d pts=%lld", packet_type_name, pkt->data_size, pkt->pts);
   MEM_DUMP (pkt->data, pkt->data_size, "Buffer=");
 }
 
@@ -36,7 +36,7 @@ parseFile (const char *fileName, const char* options, uint8_t debug_level)
   ESEResult res;
   ESEPacket *pkt;
   ESExtractor *esextractor;
-  int frame_count;
+  int packet_count;
 
   es_extractor_set_log_level (debug_level);
   esextractor = es_extractor_new (fileName, options);
@@ -45,20 +45,20 @@ parseFile (const char *fileName, const char* options, uint8_t debug_level)
     ERR ("Unable to discover a compatible stream. Exit");
     return -1;
   }
-  INFO ("Extracting frames from %s with options %s", fileName, options);
+  INFO ("Extracting packets from %s with options %s", fileName, options);
   while ((res =
-          es_extractor_read_frame (esextractor,
+          es_extractor_read_packet (esextractor,
               &pkt)) < ESE_RESULT_EOS) {
 
     dumpPacket (esextractor, pkt);
     es_extractor_clear_packet (pkt);
   }
 
-  frame_count = es_extractor_frame_count (esextractor);
-  INFO ("Got %d frame(s)", frame_count);
+  packet_count = es_extractor_packet_count (esextractor);
+  INFO ("Got %d packet(s)", packet_count);
   es_extractor_teardown (esextractor);
 
-  return frame_count;
+  return packet_count;
 }
 
 


### PR DESCRIPTION
In order to unify the API, use the keyword packet
everywhere instead of frame.