### PR TITLE
 esextractor: extend the test suite and address remaining issues

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Test
         run: |
-          meson test --num-processes=1 --wrap=${GITHUB_WORKSPACE}/valgrind/valgrind.sh --verbose --timeout-multiplier=2 -C builddir
+          meson test --wrap=${GITHUB_WORKSPACE}/valgrind/valgrind.sh --verbose --timeout-multiplier=2 -C builddir
 
       - name: Install
         run: ninja -C builddir install

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # ESExtractor
 
 Elementary stream frame extractor:
-The purpose of this library is to parse H26x streams and extract frames with a simple API inspired from [FFmpeg](https://ffmpeg.org) API 
-[av_read_frame](https://ffmpeg4d.dpldocs.info/ffmpeg.libavformat.avformat.av_read_frame.html). 
-The H26x frame can be [NAL](https://en.wikipedia.org/wiki/Network_Abstraction_Layer) or [AUs](https://en.wikipedia.org/wiki/Network_Abstraction_Layer#Access_Units)
+The purpose of this library is to parse streams and extract frames with a simple API inspired from [FFmpeg](https://ffmpeg.org) API
+[av_read_frame](https://ffmpeg4d.dpldocs.info/ffmpeg.libavformat.avformat.av_read_frame.html).
 
+It supports:
+  - NAL based streams which can be [NAL](https://en.wikipedia.org/wiki/Network_Abstraction_Layer) or [AUs](https://en.wikipedia.org/wiki/Network_Abstraction_Layer#Access_Units) aligned
+  - IVF based streams
 
 ## Setup
 
@@ -28,5 +30,11 @@ $ pip3 install --user meson
 ```sh
 $ meson builddir
 $ ninja -C builddir
-$ meson builddir test
+$ meson test -C builddir
+```
+
+### Test with a sample
+
+```
+$ ./builddir/tests/testesextractor -d -d -f samples/clip-a.h264
 ```

--- a/lib/eseivfstream.cpp
+++ b/lib/eseivfstream.cpp
@@ -32,8 +32,8 @@ struct IVFFrameHeader
 
 ESEIVFStream::ESEIVFStream ():
 ESEStream (ESE_VIDEO_FORMAT_IVF),
-m_header_found (false),
-m_last_pts (false)
+m_headerFound (false),
+m_lastPts (false)
 {
 }
 
@@ -75,10 +75,10 @@ ESEIVFStream::processToNextFrame ()
   if (m_reader.isEOS ())
     return ESE_RESULT_EOS;
 
-  if (!m_header_found) {
+  if (!m_headerFound) {
     m_buffer = m_reader.getBuffer (sizeof (IVFHeader));
     std::memcpy (&m_header, m_buffer.data (), sizeof (IVFHeader));
-    m_header_found = true;
+    m_headerFound = true;
     m_codec = fourccToCodec ();
   }
   m_buffer = m_reader.getBuffer (sizeof (IVFFrameHeader));
@@ -89,9 +89,9 @@ ESEIVFStream::processToNextFrame ()
   m_currentFrame = prepareFrame (m_buffer, 0, m_buffer.size ());
 
   prepareCurrentPacket (frame_header.timestamp, frame_header.timestamp,
-      m_last_pts - frame_header.timestamp);
+      m_lastPts - frame_header.timestamp);
 
-  m_last_pts = frame_header.timestamp;
+  m_lastPts = frame_header.timestamp;
 
   if (m_reader.isEOS ())
     res = ESE_RESULT_LAST_PACKET;

--- a/lib/eseivfstream.h
+++ b/lib/eseivfstream.h
@@ -48,8 +48,8 @@ private:
   void parseOptions(const char* options);
 
   IVFHeader m_header;
-  bool m_header_found;
-  uint64_t m_last_pts;
+  bool m_headerFound;
+  uint64_t m_lastPts;
 };
 
 #endif //__ESE_IVFSTREAM_H__

--- a/lib/eseivfstream.h
+++ b/lib/eseivfstream.h
@@ -15,8 +15,7 @@
  * permissions and limitations under the License.
  */
 
-#ifndef __ESE_IVFSTREAM_H__
-#define __ESE_IVFSTREAM_H__
+#pragma once
 
 #include "esestream.h"
 
@@ -53,5 +52,3 @@ private:
   bool m_headerFound;
   uint64_t m_lastPts;
 };
-
-#endif //__ESE_IVFSTREAM_H__

--- a/lib/eseivfstream.h
+++ b/lib/eseivfstream.h
@@ -39,6 +39,8 @@ public:
   ESEIVFStream ();
   ~ESEIVFStream ();
 
+  virtual void reset ();
+
 protected:
   ESEBuffer getStartCode() {return {};}
   ESEResult processToNextFrame();

--- a/lib/eselogger.h
+++ b/lib/eselogger.h
@@ -15,8 +15,7 @@
  * permissions and limitations under the License.
  */
 
-#ifndef __ESE_LOGGER_H__
-#define __ESE_LOGGER_H__
+#pragma once
 
 #include <stdarg.h>
 #include <string.h>
@@ -80,5 +79,3 @@ class Logger {
 
 #define DBG(FMT, ...) LOGGER(ES_LOG_LEVEL_DEBUG, "ESE_DEBUG\t", FMT, "\n", ##__VA_ARGS__)
 #define MEM_DUMP(DATA, LENGTH, FMT, ...) LOGGER_DATA(ES_LOG_LEVEL_MEMDUMP, DATA, LENGTH, "ESE_MEMDUMP\t", FMT, "", ##__VA_ARGS__)
-
-#endif // __ESE_LOGGER_H__

--- a/lib/esenalstream.cpp
+++ b/lib/esenalstream.cpp
@@ -28,7 +28,7 @@ ESENALStream::ESENALStream ():
 ESEStream (ESE_VIDEO_FORMAT_NAL),
 m_frameState (ESE_NAL_FRAME_STATE_NONE),
 m_nalCount (false),
-m_mpeg_detected (false),
+m_mpegDetected (false),
 m_audNalDetected (false),
 m_alignment (ESE_PACKET_ALIGNMENT_AU)
 {
@@ -68,19 +68,19 @@ ESENALStream::parseStream (int32_t start_position)
   int32_t buffer_size = m_buffer.size ();
 
   while (pos < buffer_size) {
-    if (!m_mpeg_detected) {
+    if (!m_mpegDetected) {
       pos = probeH26x ();
       if (pos > 0) {
         /* start code might have 2 or 3 0-bytes */
         m_frameStartPos = pos;
         m_frameState = ESE_NAL_FRAME_STATE_START;
-        m_mpeg_detected = true;
+        m_mpegDetected = true;
       } else {
         ERR ("Unable to find any start code in buffer size %d. Exit.",
             buffer_size);
         return -1;
       }
-    } else if (m_mpeg_detected && m_codec != ESE_VIDEO_CODEC_UNKNOWN) {
+    } else if (m_mpegDetected && m_codec != ESE_VIDEO_CODEC_UNKNOWN) {
       pos = scanMPEGHeader (m_buffer, pos);
       if (pos >= 0) {
         DBG ("Found a NAL delimiter, stop pos %d ", pos);

--- a/lib/esenalstream.h
+++ b/lib/esenalstream.h
@@ -15,8 +15,7 @@
  * permissions and limitations under the License.
  */
 
-#ifndef __ESE_NALSTREAM_H__
-#define __ESE_NALSTREAM_H__
+#pragma once
 
 #include <vector>
 
@@ -69,5 +68,3 @@ private:
   ESEPacketAlignment          m_alignment;
   ESEBuffer                   m_nextFrame;
 };
-
-#endif //__ESE_NALSTREAM_H__

--- a/lib/esenalstream.h
+++ b/lib/esenalstream.h
@@ -40,6 +40,9 @@ class ESENALStream : public ESEStream {
 public:  
   ESENALStream ();
   ~ESENALStream ();
+
+  virtual void reset();
+
   ESEResult processToNextFrame();
   /// @brief Returns the NAL count.
   /// @return
@@ -58,12 +61,13 @@ private:
   const char* alignmentName();
 
   ESENALFrameState            m_frameState;
+  int32_t                     m_frameStartPos;
   uint32_t                    m_nalCount;
   bool                        m_mpegDetected;
   ESEBuffer                   m_nextNAL;
   bool                        m_audNalDetected;
   ESEPacketAlignment          m_alignment;
-
+  ESEBuffer                   m_nextFrame;
 };
 
 #endif //__ESE_NALSTREAM_H__

--- a/lib/esenalstream.h
+++ b/lib/esenalstream.h
@@ -59,7 +59,7 @@ private:
 
   ESENALFrameState            m_frameState;
   uint32_t                    m_nalCount;
-  bool                        m_mpeg_detected;
+  bool                        m_mpegDetected;
   ESEBuffer                   m_nextNAL;
   bool                        m_audNalDetected;
   ESEPacketAlignment          m_alignment;

--- a/lib/esenalu.h
+++ b/lib/esenalu.h
@@ -15,11 +15,9 @@
  * permissions and limitations under the License.
  */
 
-\
+#pragma once
+
 #include "esereader.h"
-
-
-
 
 typedef enum ESENaluCategory {
   ESE_NALU_CATEGORY_UNKNOWN,

--- a/lib/esereader.cpp
+++ b/lib/esereader.cpp
@@ -42,18 +42,22 @@ ESEReader::reset (bool full)
 bool
 ESEReader::openFile (const char *fileName)
 {
-  bool ret = false;
   if (m_file.is_open ())
     return true;
+
+  if (!fileName)
+    return false;
+
   m_file = std::ifstream (fileName, std::ios::binary | std::ios::ate);
   DBG ("The file %s is now %s", fileName, m_file.is_open ()? "open" : "closed");
   if (m_file.is_open ()) {
     m_fileSize = m_file.tellg ();
-    ret = true;
     m_fileName = fileName;
-  } else
-    ERR ("Unable to open the file %s", fileName);
-  return ret;
+    return true;
+  }
+
+  ERR ("Unable to open the file %s", fileName);
+  return false;
 }
 
 uint32_t ESEReader::readFile (int32_t data_size, int32_t pos, bool append)

--- a/lib/esereader.cpp
+++ b/lib/esereader.cpp
@@ -50,6 +50,7 @@ ESEReader::openFile (const char *fileName)
   if (m_file.is_open ()) {
     m_fileSize = m_file.tellg ();
     ret = true;
+    m_fileName = fileName;
   } else
     ERR ("Unable to open the file %s", fileName);
   return ret;

--- a/lib/esereader.h
+++ b/lib/esereader.h
@@ -23,6 +23,7 @@
 #include <fstream>
 #include <istream>
 #include <vector>
+#include <string>
 
 #define ESEBuffer std::vector <unsigned char>
 
@@ -58,6 +59,7 @@ private:
   uint32_t readFile(int32_t data_size, int32_t pos = 0, bool append = false );
 
   std::ifstream               m_file;
+  std::string                 m_fileName;
   int32_t                     m_filePosition;
   int32_t                     m_fileSize;
 

--- a/lib/esereader.h
+++ b/lib/esereader.h
@@ -15,8 +15,7 @@
  * permissions and limitations under the License.
  */
 
-#ifndef __ESE_READER_H__
-#define __ESE_READER_H__
+#pragma once
 
 #include <cstdint>
 #include <iostream>
@@ -68,5 +67,3 @@ private:
   int32_t                     m_readSize;
   ESEBuffer                   m_buffer;
 };
-
-#endif //__ESE_READER_H__

--- a/lib/esestream.cpp
+++ b/lib/esestream.cpp
@@ -80,6 +80,11 @@ ESEStream::prepare (const char *uri, const char *options)
   return (processToNextFrame() <= ESE_RESULT_ERROR);
 }
 
+void ESEStream::setOptions (const char *options)
+{
+  parseOptions (options);
+}
+
 ESEBuffer
 ESEStream::prepareFrame (ESEBuffer buffer, uint32_t start,
     uint32_t end)

--- a/lib/esestream.cpp
+++ b/lib/esestream.cpp
@@ -112,7 +112,8 @@ ESEPacket *
 ESEStream::prepareNextPacket (uint64_t pts, uint64_t dts, uint64_t duration)
 {
   m_nextPacket = new ESEPacket ();
-  m_nextPacket->data = m_currentFrame.data ();
+  m_nextPacket->data = static_cast<std::uint8_t*>(std::malloc(m_currentFrame.size ()));
+  std::memcpy (m_nextPacket->data, m_currentFrame.data (), m_currentFrame.size ());
   m_nextPacket->data_size = m_currentFrame.size ();
   m_nextPacket->pts = pts;
   m_nextPacket->dts = dts;

--- a/lib/esestream.h
+++ b/lib/esestream.h
@@ -101,20 +101,20 @@ protected:
   ESEBuffer  prepareFrame(ESEBuffer  buffer, uint32_t start, uint32_t end);
   ESEPacket* prepareCurrentPacket (uint64_t pts = 0, uint64_t dts = 0, uint64_t duration = 0);
 
-  int32_t                     m_frameStartPos;
-  int32_t                     m_frameStartCodeLen;
-  ESEVideoCodec               m_codec;
-  ESEVideoFormat              m_format;
-  std::map<std::string, std::string> m_options;
+  int32_t                             m_frameStartPos;
+  int32_t                             m_frameStartCodeLen;
+  ESEVideoCodec                       m_codec;
+  ESEVideoFormat                      m_format;
+  std::map<std::string, std::string>  m_options;
   
-  bool                        m_eos;
-  ESEBuffer   m_buffer;
-  uint32_t                    m_bufferPosition;
+  bool                                m_eos;
+  ESEBuffer                           m_buffer;
+  uint32_t                            m_bufferPosition;
 
-  ESEBuffer   m_nextFrame;
-  ESEBuffer   m_currentFrame;
-  uint32_t                    m_frameCount;
-  ESEPacket*                  m_currentPacket;
+  ESEBuffer                           m_nextFrame;
+  ESEBuffer                           m_currentFrame;
+  uint32_t                            m_frameCount;
+  ESEPacket*                          m_currentPacket;
 };
 
 #endif //__ESE_STREAM_H__

--- a/lib/esestream.h
+++ b/lib/esestream.h
@@ -75,6 +75,7 @@ public:
   virtual void reset();
 
   bool prepare (const char* uri, const char* options = nullptr);
+  void setOptions (const char *options);
   virtual void parseOptions(const char* options);
   /// @brief This method will build the next frame (NAL or AU) available.
   /// @return

--- a/lib/esestream.h
+++ b/lib/esestream.h
@@ -86,7 +86,8 @@ public:
   bool isH264 (ESEBuffer buffer);
   bool isH265 (ESEBuffer buffer);
 
-  ESEVideoCodec codec() { return m_codec;};
+  ESEVideoCodec codec() { return m_codec;}
+  ESEVideoFormat format() { return m_format;}
   ESEBuffer * currentFrame() { return &m_currentFrame;}
   ESEPacket*                  currentPacket();
 

--- a/lib/esestream.h
+++ b/lib/esestream.h
@@ -72,6 +72,8 @@ public:
   ESEStream (ESEVideoFormat format = ESE_VIDEO_FORMAT_UNKNOWN);
   virtual ~ESEStream ();
 
+  virtual void reset();
+
   bool prepare (const char* uri, const char* options = nullptr);
   virtual void parseOptions(const char* options);
   /// @brief This method will build the next frame (NAL or AU) available.
@@ -86,7 +88,7 @@ public:
 
   ESEVideoCodec codec() { return m_codec;};
   ESEBuffer * currentFrame() { return &m_currentFrame;}
-  ESEPacket*                  currentPacket() { return m_currentPacket;}
+  ESEPacket*                  currentPacket();
 
   /// @brief Returns the frame count.
   /// @return
@@ -99,10 +101,8 @@ protected:
 
   // Prepare the next frame available from the given buffer at given position.
   ESEBuffer  prepareFrame(ESEBuffer  buffer, uint32_t start, uint32_t end);
-  ESEPacket* prepareCurrentPacket (uint64_t pts = 0, uint64_t dts = 0, uint64_t duration = 0);
+  ESEPacket* prepareNextPacket (uint64_t pts = 0, uint64_t dts = 0, uint64_t duration = 0);
 
-  int32_t                             m_frameStartPos;
-  int32_t                             m_frameStartCodeLen;
   ESEVideoCodec                       m_codec;
   ESEVideoFormat                      m_format;
   std::map<std::string, std::string>  m_options;
@@ -111,10 +111,10 @@ protected:
   ESEBuffer                           m_buffer;
   uint32_t                            m_bufferPosition;
 
-  ESEBuffer                           m_nextFrame;
   ESEBuffer                           m_currentFrame;
   uint32_t                            m_frameCount;
   ESEPacket*                          m_currentPacket;
+  ESEPacket*                          m_nextPacket;
 };
 
 #endif //__ESE_STREAM_H__

--- a/lib/esestream.h
+++ b/lib/esestream.h
@@ -18,9 +18,9 @@
 #pragma once
 
 #include "esereader.h"
+#include "esextractor.h"
 
 #include <vector>
-#include <cstdint>
 #include <cstring>
 #include <string>
 #include <map>
@@ -29,40 +29,6 @@
   ( (uint32_t)(a) | ((uint32_t) (b)) << 8  | ((uint32_t) (c)) << 16 | ((uint32_t) (d)) << 24 )
 
 #define BUFFER_MAX_PROBE_LENGTH (128 * 1024)
-
-typedef enum ESEVideoCodec {
-  ESE_VIDEO_CODEC_UNKNOWN = 0,
-  ESE_VIDEO_CODEC_H264,
-  ESE_VIDEO_CODEC_H265,
-  ESE_VIDEO_CODEC_VP8,
-  ESE_VIDEO_CODEC_VP9,
-  ESE_VIDEO_CODEC_AV1,
-} ESEVideoCodec;
-
-typedef enum ESEVideoFormat {
-  ESE_VIDEO_FORMAT_UNKNOWN = 0,
-  ESE_VIDEO_FORMAT_NAL,
-  ESE_VIDEO_FORMAT_IVF,
-} ESEVideoFormat;
-
-typedef enum _ESEResult
-{
-  /*< public >*/
-  ESE_RESULT_NEW_PACKET = 0,
-  ESE_RESULT_LAST_PACKET,
-  ESE_RESULT_EOS,
-  ESE_RESULT_NO_PACKET ,
-  ESE_RESULT_ERROR,
-} ESEResult;
-
-typedef struct _ESEPacket {
-    uint8_t * data;
-    int32_t data_size;
-    int32_t packet_number;
-    uint64_t pts;
-    uint64_t dts;
-    uint64_t duration;
-} ESEPacket;
 
 ESEVideoFormat ese_stream_probe_video_format (const char* uri);
 

--- a/lib/esestream.h
+++ b/lib/esestream.h
@@ -15,8 +15,7 @@
  * permissions and limitations under the License.
  */
 
-#ifndef __ESE_STREAM_H__
-#define __ESE_STREAM_H__
+#pragma once
 
 #include "esereader.h"
 
@@ -118,5 +117,3 @@ protected:
   ESEPacket*                          m_currentPacket;
   ESEPacket*                          m_nextPacket;
 };
-
-#endif //__ESE_STREAM_H__

--- a/lib/eseutils.h
+++ b/lib/eseutils.h
@@ -1,0 +1,44 @@
+/* ESExtractor
+ * Copyright (C) 2022 Igalia, S.L.
+ *     Author: Stephane Cerveau <scerveau@igalia.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You
+ * may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#pragma once
+
+#if (__cplusplus < 201402L)
+#include <memory>
+template<class T, class... Args>
+std::unique_ptr<T> make_unique(Args&&... args)
+{
+    return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
+}
+#else
+# define make_unique std::make_unique
+#endif
+
+#define ESE_CHECK(expr, val) \
+  if (expr) \
+    { } \
+  else {\
+    ERR ("Check '%s' fails", #expr);\
+    return val;\
+  }
+#define ESE_CHECK_VOID(expr) \
+  if (expr) \
+   { } \
+   else { \
+     ERR ("Check '%s' fails", #expr);\
+    return;\
+  }

--- a/lib/esextractor.cpp
+++ b/lib/esextractor.cpp
@@ -163,8 +163,10 @@ es_extractor_packet_count (ESExtractor * extractor)
 void
 es_extractor_clear_packet (ESEPacket * pkt)
 {
-  if (pkt)
+  if (pkt) {
+    std::free (pkt->data);
     delete pkt;
+  }
 }
 
 void

--- a/lib/esextractor.cpp
+++ b/lib/esextractor.cpp
@@ -20,6 +20,7 @@
 #include "esenalstream.h"
 #include "eselogger.h"
 
+#include <assert.h>
 
 ESExtractor::ESExtractor ():
 m_stream (nullptr)
@@ -107,6 +108,14 @@ ESExtractor::prepare (const char *uri, const char *options)
   return false;
 }
 
+void ESExtractor::setOptions (const char *options)
+{
+    assert(m_stream);
+    m_stream->reset ();
+    m_stream->setOptions (options);
+    m_stream->processToNextFrame();
+}
+
 //C API
 
 ESExtractor *
@@ -119,6 +128,11 @@ es_extractor_new (const char *uri, const char *options)
 
   es_extractor_teardown (extractor);
   return NULL;
+}
+
+void es_extractor_set_options (ESExtractor * extractor, const char* options)
+{
+  extractor->setOptions (options);
 }
 
 ESEResult

--- a/lib/esextractor.cpp
+++ b/lib/esextractor.cpp
@@ -87,7 +87,6 @@ ESEResult ESExtractor::processToNextPacket ()
 bool
 ESExtractor::prepare (const char *uri, const char *options)
 {
-  bool found = false;
   ESEVideoFormat format = ese_stream_probe_video_format (uri);
   m_stream = NULL;
   if (format == ESE_VIDEO_FORMAT_NAL) {
@@ -95,9 +94,10 @@ ESExtractor::prepare (const char *uri, const char *options)
   } else if (format == ESE_VIDEO_FORMAT_IVF) {
     m_stream = new ESEIVFStream ();
   }
-  if (m_stream && m_stream->prepare (uri, options))
-    found = true;
-  return found;
+  if (m_stream && m_stream->prepare (uri, options)) {
+    return (m_stream->processToNextFrame()  <= ESE_RESULT_ERROR);
+  }
+  return false;
 }
 
 //C API

--- a/lib/esextractor.cpp
+++ b/lib/esextractor.cpp
@@ -32,6 +32,13 @@ ESExtractor::~ESExtractor ()
     delete m_stream;
 }
 
+ESEVideoFormat ESExtractor::format ()
+{
+  if (m_stream)
+    return m_stream->format ();
+  return ESE_VIDEO_FORMAT_UNKNOWN;
+}
+
 ESEVideoCodec ESExtractor::codec ()
 {
   if (m_stream)
@@ -131,6 +138,12 @@ ESEVideoCodec
 es_extractor_video_codec (ESExtractor * extractor)
 {
   return extractor->codec ();
+}
+
+ESEVideoFormat
+es_extractor_video_format (ESExtractor * extractor)
+{
+  return extractor->format ();
 }
 
 const char *

--- a/lib/esextractor.h
+++ b/lib/esextractor.h
@@ -17,7 +17,41 @@
 
 #pragma once
 
-#include "esestream.h"
+#include <cstdint>
+
+typedef enum ESEVideoCodec {
+  ESE_VIDEO_CODEC_UNKNOWN = 0,
+  ESE_VIDEO_CODEC_H264,
+  ESE_VIDEO_CODEC_H265,
+  ESE_VIDEO_CODEC_VP8,
+  ESE_VIDEO_CODEC_VP9,
+  ESE_VIDEO_CODEC_AV1,
+} ESEVideoCodec;
+
+typedef enum ESEVideoFormat {
+  ESE_VIDEO_FORMAT_UNKNOWN = 0,
+  ESE_VIDEO_FORMAT_NAL,
+  ESE_VIDEO_FORMAT_IVF,
+} ESEVideoFormat;
+
+typedef enum _ESEResult
+{
+  /*< public >*/
+  ESE_RESULT_NEW_PACKET = 0,
+  ESE_RESULT_LAST_PACKET,
+  ESE_RESULT_EOS,
+  ESE_RESULT_NO_PACKET ,
+  ESE_RESULT_ERROR,
+} ESEResult;
+
+typedef struct _ESEPacket {
+    uint8_t * data;
+    int32_t data_size;
+    int32_t packet_number;
+    uint64_t pts;
+    uint64_t dts;
+    uint64_t duration;
+} ESEPacket;
 
 
 #if (defined _WIN32 || defined __CYGWIN__) && !defined(ES_STATIC_COMPILATION)
@@ -34,61 +68,38 @@
   #endif
 #endif
 
-class ESExtractor {
-public:
-  ESExtractor();
-  ~ESExtractor();
-  bool prepare(const char *uri, const char* options);
-  void setOptions(const char* options);
-  /// @brief This method will build the next frame (NAL or AU) available.
-  /// @return
-  ESEResult processToNextPacket();
-  ESEVideoCodec codec();
-  ESEVideoFormat format();
-  const char* codec_name();
-
-  /// @brief Reset the extractor state
-  ESEPacket* currentPacket();
-  /// @brief Returns the packet count.
-  /// @return
-  int packetCount();
-
-private:
-
-  ESEStream* m_stream;
-};
-
+struct ESExtractor;
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 ES_EXTRACTOR_API
-ESExtractor * es_extractor_new (const char * uri, const char* options);
+ESExtractor * es_extractor_new (const char *uri, const char *options);
 
 ES_EXTRACTOR_API
-void es_extractor_set_options (ESExtractor * extractor, const char* options);
+void es_extractor_set_options (ESExtractor *extractor, const char *options);
 
 ES_EXTRACTOR_API
-ESEResult es_extractor_read_packet (ESExtractor * extractor, ESEPacket ** pkt);
+ESEResult es_extractor_read_packet (ESExtractor *extractor, ESEPacket **pkt);
 
 ES_EXTRACTOR_API
-void es_extractor_clear_packet (ESEPacket * pkt);
+void es_extractor_clear_packet (ESEPacket *pkt);
 
 ES_EXTRACTOR_API
-ESEVideoFormat es_extractor_video_format(ESExtractor * extractor);
+ESEVideoFormat es_extractor_video_format(ESExtractor *extractor);
 
 ES_EXTRACTOR_API
-ESEVideoCodec es_extractor_video_codec(ESExtractor * extractor);
+ESEVideoCodec es_extractor_video_codec(ESExtractor *extractor);
 
 ES_EXTRACTOR_API
-const char* es_extractor_video_codec_name(ESExtractor * extractor);
+const char* es_extractor_video_codec_name(ESExtractor *extractor);
 
 ES_EXTRACTOR_API
-int es_extractor_packet_count (ESExtractor * extractor);
+int es_extractor_packet_count (ESExtractor *extractor);
 
 ES_EXTRACTOR_API
-void es_extractor_teardown (ESExtractor * extractor);
+void es_extractor_teardown (ESExtractor *extractor);
 
 ES_EXTRACTOR_API
 void es_extractor_set_log_level (uint8_t level);

--- a/lib/esextractor.h
+++ b/lib/esextractor.h
@@ -15,8 +15,7 @@
  * permissions and limitations under the License.
  */
 
-#ifndef __ESE_EXTRACTOR_H__
-#define __ESE_EXTRACTOR_H__
+#pragma once
 
 #include "esestream.h"
 
@@ -97,4 +96,3 @@ void es_extractor_set_log_level (uint8_t level);
 #ifdef __cplusplus
 }
 #endif
-#endif //__ESE_EXTRACTOR_H__

--- a/lib/esextractor.h
+++ b/lib/esextractor.h
@@ -52,8 +52,6 @@ public:
   /// @return
   int packetCount();
 
-  bool openFile (const char *uri);
-
 private:
 
   ESEStream* m_stream;
@@ -71,6 +69,9 @@ ES_EXTRACTOR_API
 ESEResult es_extractor_read_packet (ESExtractor * demuxer, ESEPacket ** pkt);
 
 ES_EXTRACTOR_API
+ESEResult es_extractor_read_packet (ESExtractor * extractor, ESEPacket ** pkt);
+
+ES_EXTRACTOR_API
 void es_extractor_clear_packet (ESEPacket * pkt);
 
 ES_EXTRACTOR_API
@@ -83,7 +84,7 @@ ES_EXTRACTOR_API
 int es_extractor_packet_count (ESExtractor * extractor);
 
 ES_EXTRACTOR_API
-void es_extractor_teardown (ESExtractor * demuxer);
+void es_extractor_teardown (ESExtractor * extractor);
 
 ES_EXTRACTOR_API
 void es_extractor_set_log_level (uint8_t level);

--- a/lib/esextractor.h
+++ b/lib/esextractor.h
@@ -44,6 +44,7 @@ public:
   /// @return
   ESEResult processToNextPacket();
   ESEVideoCodec codec();
+  ESEVideoFormat format();
   const char* codec_name();
 
   /// @brief Reset the extractor state
@@ -73,6 +74,9 @@ ESEResult es_extractor_read_packet (ESExtractor * extractor, ESEPacket ** pkt);
 
 ES_EXTRACTOR_API
 void es_extractor_clear_packet (ESEPacket * pkt);
+
+ES_EXTRACTOR_API
+ESEVideoFormat es_extractor_video_format(ESExtractor * extractor);
 
 ES_EXTRACTOR_API
 ESEVideoCodec es_extractor_video_codec(ESExtractor * extractor);

--- a/lib/esextractor.h
+++ b/lib/esextractor.h
@@ -40,6 +40,7 @@ public:
   ESExtractor();
   ~ESExtractor();
   bool prepare(const char *uri, const char* options);
+  void setOptions(const char* options);
   /// @brief This method will build the next frame (NAL or AU) available.
   /// @return
   ESEResult processToNextPacket();
@@ -67,7 +68,7 @@ ES_EXTRACTOR_API
 ESExtractor * es_extractor_new (const char * uri, const char* options);
 
 ES_EXTRACTOR_API
-ESEResult es_extractor_read_packet (ESExtractor * demuxer, ESEPacket ** pkt);
+void es_extractor_set_options (ESExtractor * extractor, const char* options);
 
 ES_EXTRACTOR_API
 ESEResult es_extractor_read_packet (ESExtractor * extractor, ESEPacket ** pkt);

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -9,7 +9,6 @@ esextractor_sources = files(
 
 esextractor_headers = files(
   'esextractor.h',
-  'esestream.h'
 )
 
 install_headers(esextractor_headers)

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('esextractor', 'c', 'cpp',
-  default_options : [ 'buildtype=debug', 'cpp_std=c++17' ],
+  default_options : [ 'buildtype=debug', 'cpp_std=c++11' ],
   version: '0.0.1'
 )
 

--- a/tests/testbin.cpp
+++ b/tests/testbin.cpp
@@ -15,12 +15,12 @@
  * permissions and limitations under the License.
  */
 
-
-#include "testese.h"
 #include <algorithm>
 #include <fstream>
 #include <iostream>
 #include <vector>
+
+#include "testese.h"
 
 class CmdLineParser{
     public:
@@ -80,5 +80,5 @@ main (int argc, char *argv[])
     return 1;
   }
 
-  return (int)(parseFile (fileName.c_str(), option.c_str(), debug) < 0);
+  return (int)(parse_file (fileName.c_str(), option.c_str(), debug) < 0);
 }

--- a/tests/testese.cpp
+++ b/tests/testese.cpp
@@ -15,50 +15,66 @@
  * permissions and limitations under the License.
  */
 
+#include <fstream>
+#include <algorithm>
+#include <cassert>
+
 #include "esextractor.h"
 #include "eselogger.h"
 
-#include <fstream>
-#include <algorithm>
-
 
 static void
-dumpPacket (ESExtractor * esextractor, ESEPacket* pkt)
+dump_packet (ESExtractor * esextractor, ESEPacket* pkt)
 {
   const char *packet_type_name = es_extractor_video_codec_name (esextractor);
-  DBG ("Got a %s packet of size %d pts=%lld", packet_type_name, pkt->data_size, pkt->pts);
+  INFO ("Got a %s packet of size %d pts=%lld", packet_type_name, pkt->data_size, pkt->pts);
   MEM_DUMP (pkt->data, pkt->data_size, "Buffer=");
 }
 
+/// @brief Return a new esextactor
+/// @param fileName the file path to extract frames from
+/// @param options Options used by the esextractor
+/// @param debug_level set the debug level of the esextractor
+/// @return a new esextractor object or nullptr if the path is not a valid media file.
+ESExtractor*
+create_es_extractor (const char *fileName, const char* options, uint8_t debug_level) {
+  es_extractor_set_log_level (debug_level);
+  INFO ("Extracting packets from %s with options %s", fileName, options);
+  ESExtractor *esextractor = es_extractor_new (fileName, options);
+  return esextractor;
+}
+
+
+/// @brief  Returns the number of frame found
+/// @param extractor a valid extractor
+/// @return the number of frames
 int
-parseFile (const char *fileName, const char* options, uint8_t debug_level)
+parse (ESExtractor* esextractor)
 {
   ESEResult res;
   ESEPacket *pkt;
-  ESExtractor *esextractor;
   int packet_count;
 
-  es_extractor_set_log_level (debug_level);
-  esextractor = es_extractor_new (fileName, options);
-
-  if (!esextractor) {
-    ERR ("Unable to discover a compatible stream. Exit");
-    return -1;
-  }
-  INFO ("Extracting packets from %s with options %s", fileName, options);
   while ((res =
           es_extractor_read_packet (esextractor,
               &pkt)) < ESE_RESULT_EOS) {
 
-    dumpPacket (esextractor, pkt);
+    dump_packet (esextractor, pkt);
     es_extractor_clear_packet (pkt);
   }
 
   packet_count = es_extractor_packet_count (esextractor);
   INFO ("Got %d packet(s)", packet_count);
-  es_extractor_teardown (esextractor);
-
   return packet_count;
 }
 
-
+int parse_file (const char *fileName, const char* options, uint8_t debug_level) {
+  ESExtractor* esextractor = create_es_extractor (fileName, options, debug_level);
+  if (!esextractor) {
+    ERR ("Unable to discover a compatible stream. Exit");
+    return -1;
+  }
+  int packet_count = parse(esextractor);
+  es_extractor_teardown (esextractor);
+  return packet_count;
+}

--- a/tests/testese.h
+++ b/tests/testese.h
@@ -18,5 +18,8 @@
 #pragma once
 
 #include "eselogger.h"
+#include "esextractor.h"
 
-int parseFile (const char *fileName, const char* options, uint8_t debug_level);
+ESExtractor* create_es_extractor (const char *fileName, const char* options, uint8_t debug_level);
+int parse (ESExtractor* extractor);
+int parse_file (const char *fileName, const char* options, uint8_t debug_level);

--- a/tests/testsuite.cpp
+++ b/tests/testsuite.cpp
@@ -67,5 +67,11 @@ main (int argc, char *argv[])
   assert(parse_file (nullptr, nullptr, log_level) == -1);
   assert(parse_file ("/this/path/does/not/exists", nullptr, log_level) == -1);
 
+  assert(es_extractor_read_packet(nullptr, nullptr) == ESE_RESULT_ERROR);
+  assert(es_extractor_packet_count(nullptr) == -1);
+  assert(es_extractor_video_format(nullptr) == ESE_VIDEO_FORMAT_UNKNOWN);
+  assert(es_extractor_video_codec(nullptr) == ESE_VIDEO_CODEC_UNKNOWN);
+  assert(es_extractor_video_codec_name(nullptr) == nullptr);
+
   return 0;
 }


### PR DESCRIPTION
esereader: fix valgrind error with null filename
f958ee8 esextractor: remove c++ api
c653855 esextractor: use pragma once
71bd1f2 test: extend the testsuite with new APIs
8eb03af esextractor: add es_extractor_set_options api
a5ddff2 esextractor: add api to get the stream format
77e9d39 esestream: start to parse on prepare
5d97ece esnalstream: unify variables names

