### PR TITLE
esextractor: add clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,16 @@
+---
+BasedOnStyle:  WebKit
+
+AlwaysBreakAfterReturnType: TopLevel
+ConstructorInitializerIndentWidth: 0
+ContinuationIndentWidth: 2
+IndentCaseLabels: true
+IndentPPDirectives: AfterHash
+IndentWidth:     2
+PointerAlignment: Right
+SpaceBeforeParens: Always
+
+---
+# Language: ObjC
+# PointerAlignment: Right
+...

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,17 @@ env:
   REPO_NAME: ESExtractor
 
 jobs:
+  clang-format:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Install Clang-Format
+      run: sudo apt-get update && sudo apt-get -y install clang-format
+    - name: Run Clang-Format
+      run:  |
+        find . -name "*.cpp" -o -name "*.hpp" | xargs -I {} clang-format -i {} -n --verbose --Werror
+
   ci-linux-x86_64:
     strategy:
       matrix:

--- a/lib/eseivfstream.cpp
+++ b/lib/eseivfstream.cpp
@@ -19,19 +19,18 @@
 #include "eselogger.h"
 #include "esereader.h"
 
-#define IVF_HEADER_SIZE sizeof(IVFHeader)
-#define IVF_FRAME_HEADER_SIZE sizeof(IVFFrameHeader)
+#define IVF_HEADER_SIZE sizeof (IVFHeader)
+#define IVF_FRAME_HEADER_SIZE sizeof (IVFFrameHeader)
 
-#pragma pack(push,1)
-struct IVFFrameHeader
-{
+#pragma pack(push, 1)
+struct IVFFrameHeader {
   uint32_t frame_size;
   uint64_t timestamp;
 };
 #pragma pack(pop)
 
-ESEIVFStream::ESEIVFStream ():
-ESEStream (ESE_VIDEO_FORMAT_IVF)
+ESEIVFStream::ESEIVFStream ()
+: ESEStream (ESE_VIDEO_FORMAT_IVF)
 {
   reset ();
 }
@@ -40,7 +39,8 @@ ESEIVFStream::~ESEIVFStream ()
 {
 }
 
-void ESEIVFStream::reset ()
+void
+ESEIVFStream::reset ()
 {
   m_headerFound = false;
   m_lastPts = 0;
@@ -98,7 +98,7 @@ ESEIVFStream::processToNextFrame ()
   m_currentFrame = prepareFrame (m_buffer, 0, m_buffer.size ());
 
   prepareNextPacket (frame_header.timestamp, frame_header.timestamp,
-      m_lastPts - frame_header.timestamp);
+    m_lastPts - frame_header.timestamp);
 
   m_lastPts = frame_header.timestamp;
 
@@ -106,7 +106,7 @@ ESEIVFStream::processToNextFrame ()
     res = ESE_RESULT_LAST_PACKET;
 
   DBG ("Found a new IVF frame (%d) of size %zd", m_frameCount,
-      m_currentFrame.size ());
+    m_currentFrame.size ());
 
   return res;
 }

--- a/lib/eseivfstream.h
+++ b/lib/eseivfstream.h
@@ -20,35 +20,34 @@
 #include "esestream.h"
 
 struct IVFHeader {
-    uint32_t signature; // FourCC
-    uint16_t version;
-    uint16_t length_header;
-    uint32_t fourcc;
-    uint16_t width;
-    uint16_t height;
-    uint32_t timescale_den;
-    uint32_t timescale_num;
-    uint32_t frame_count;
-    uint32_t unused;
+  uint32_t signature; // FourCC
+  uint16_t version;
+  uint16_t length_header;
+  uint32_t fourcc;
+  uint16_t width;
+  uint16_t height;
+  uint32_t timescale_den;
+  uint32_t timescale_num;
+  uint32_t frame_count;
+  uint32_t unused;
 };
 
-
 class ESEIVFStream : public ESEStream {
-public:  
+  public:
   ESEIVFStream ();
   ~ESEIVFStream ();
 
   virtual void reset ();
 
-protected:
-  ESEBuffer getStartCode() {return {};}
-  ESEResult processToNextFrame();
+  protected:
+  ESEBuffer getStartCode () { return {}; }
+  ESEResult processToNextFrame ();
 
-private:
-  ESEVideoCodec fourccToCodec();
-  void parseOptions(const char* options);
+  private:
+  ESEVideoCodec fourccToCodec ();
+  void          parseOptions (const char *options);
 
   IVFHeader m_header;
-  bool m_headerFound;
-  uint64_t m_lastPts;
+  bool      m_headerFound;
+  uint64_t  m_lastPts;
 };

--- a/lib/eselogger.h
+++ b/lib/eselogger.h
@@ -17,10 +17,10 @@
 
 #pragma once
 
+#include <cstdint>
+#include <cstdio>
 #include <stdarg.h>
 #include <string.h>
-#include <cstdio>
-#include <cstdint>
 
 enum {
   ES_LOG_LEVEL_NONE = 0,
@@ -33,49 +33,56 @@ enum {
 
 class Logger {
   public:
-  Logger() {
+  Logger ()
+  {
     m_level = ES_LOG_LEVEL_ERROR;
-
   }
-  static Logger& instance()
+  static Logger &instance ()
   {
     static Logger instance;
     return instance;
   }
-  int level() { return m_level;}
-  void setLogLevel(uint8_t level) {
+  int  level () { return m_level; }
+  void setLogLevel (uint8_t level)
+  {
     m_level = level;
     if (m_level > ES_LOG_LEVEL_MAX)
-      m_level=ES_LOG_LEVEL_DEBUG;
+      m_level = ES_LOG_LEVEL_DEBUG;
   }
-  void createLog(const char *format, ...) {
+  void createLog (const char *format, ...)
+  {
     va_list argptr;
-    va_start(argptr, format);
-    vfprintf(stdout, format, argptr);
-    va_end(argptr);
+    va_start (argptr, format);
+    vfprintf (stdout, format, argptr);
+    va_end (argptr);
   }
 
-  void createLogData(const uint8_t* buffer, uint32_t length, const char* format, ...) {
+  void createLogData (const uint8_t *buffer, uint32_t length, const char *format, ...)
+  {
     va_list argptr;
-    va_start(argptr, format);
-    vfprintf(stdout, format, argptr);
-    va_end(argptr);
+    va_start (argptr, format);
+    vfprintf (stdout, format, argptr);
+    va_end (argptr);
     for (uint32_t i = 0; i < length; i++) {
-      fprintf(stdout, "0x%.2X ", buffer[i]);
+      fprintf (stdout, "0x%.2X ", buffer[i]);
     }
-    fprintf(stdout, "\n");
+    fprintf (stdout, "\n");
   }
 
   private:
-    uint8_t m_level;
+  uint8_t m_level;
 };
 
-#define __FILENAME__ (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
+#define __FILENAME__ (strrchr (__FILE__, '/') ? strrchr (__FILE__, '/') + 1 : __FILE__)
 
-#define LOGGER(LEVEL, PREFIX, FMT, SUFFIX, ...) if (LEVEL <= Logger::instance().level()) Logger::instance().createLog(PREFIX "%s:%d:%s:\t"  FMT SUFFIX,__FILENAME__,__LINE__,__FUNCTION__, ##__VA_ARGS__)
-#define LOGGER_DATA(LEVEL, DATA, LENGTH, PREFIX, FMT, SUFFIX, ...) if (LEVEL <= Logger::instance().level()) Logger::instance().createLogData(DATA, LENGTH, PREFIX "%s:%d:%s:\t"  FMT SUFFIX,__FILENAME__,__LINE__,__FUNCTION__, ##__VA_ARGS__)
-#define ERR(FMT, ...) LOGGER(ES_LOG_LEVEL_ERROR, "ESE_ERROR\t", FMT, "\n", ##__VA_ARGS__)
-#define INFO(FMT, ...) LOGGER(ES_LOG_LEVEL_INFO, "ESE_INFO\t", FMT, "\n", ##__VA_ARGS__)
+#define LOGGER(LEVEL, PREFIX, FMT, SUFFIX, ...) \
+  if (LEVEL <= Logger::instance ().level ())    \
+  Logger::instance ().createLog (PREFIX "%s:%d:%s:\t" FMT SUFFIX, __FILENAME__, __LINE__, __FUNCTION__, ##__VA_ARGS__)
+#define LOGGER_DATA(LEVEL, DATA, LENGTH, PREFIX, FMT, SUFFIX, ...) \
+  if (LEVEL <= Logger::instance ().level ())                       \
+  Logger::instance ().createLogData (DATA, LENGTH, PREFIX "%s:%d:%s:\t" FMT SUFFIX, __FILENAME__, __LINE__, __FUNCTION__, ##__VA_ARGS__)
+#define ERR(FMT, ...) LOGGER (ES_LOG_LEVEL_ERROR, "ESE_ERROR\t", FMT, "\n", ##__VA_ARGS__)
+#define INFO(FMT, ...) LOGGER (ES_LOG_LEVEL_INFO, "ESE_INFO\t", FMT, "\n", ##__VA_ARGS__)
 
-#define DBG(FMT, ...) LOGGER(ES_LOG_LEVEL_DEBUG, "ESE_DEBUG\t", FMT, "\n", ##__VA_ARGS__)
-#define MEM_DUMP(DATA, LENGTH, FMT, ...) LOGGER_DATA(ES_LOG_LEVEL_MEMDUMP, DATA, LENGTH, "ESE_MEMDUMP\t", FMT, "", ##__VA_ARGS__)
+#define DBG(FMT, ...) LOGGER (ES_LOG_LEVEL_DEBUG, "ESE_DEBUG\t", FMT, "\n", ##__VA_ARGS__)
+#define MEM_DUMP(DATA, LENGTH, FMT, ...) LOGGER_DATA (ES_LOG_LEVEL_MEMDUMP, DATA, LENGTH, "ESE_MEMDUMP\t", FMT, "", ##__VA_ARGS__)

--- a/lib/esenalstream.cpp
+++ b/lib/esenalstream.cpp
@@ -23,9 +23,8 @@
 #define MPEG_HEADER_SIZE 3
 #define MAX_SEARCH_SIZE 5
 
-
-ESENALStream::ESENALStream ():
-ESEStream (ESE_VIDEO_FORMAT_NAL)
+ESENALStream::ESENALStream ()
+: ESEStream (ESE_VIDEO_FORMAT_NAL)
 {
   reset ();
 }
@@ -34,7 +33,8 @@ ESENALStream::~ESENALStream ()
 {
 }
 
-void ESENALStream::reset ()
+void
+ESENALStream::reset ()
 {
   m_frameState = ESE_NAL_FRAME_STATE_NONE;
   m_frameStartPos = 0;
@@ -42,8 +42,8 @@ void ESENALStream::reset ()
   m_mpegDetected = false;
   m_audNalDetected = false;
   m_alignment = ESE_PACKET_ALIGNMENT_NAL;
-  m_nextNAL = ESEBuffer();
-  m_nextFrame = ESEBuffer();
+  m_nextNAL = ESEBuffer ();
+  m_nextFrame = ESEBuffer ();
   ESEStream::reset ();
 }
 
@@ -86,7 +86,7 @@ ESENALStream::parseStream (int32_t start_position)
         m_mpegDetected = true;
       } else {
         ERR ("Unable to find any start code in buffer size %d. Exit.",
-            buffer_size);
+          buffer_size);
         return -1;
       }
     } else if (m_mpegDetected && m_codec != ESE_VIDEO_CODEC_UNKNOWN) {
@@ -123,33 +123,32 @@ ESENALStream::readStream ()
     return ESE_RESULT_EOS;
   }
 
-  if (m_bufferPosition >= (uint32_t) m_buffer.size ())
+  if (m_bufferPosition >= (uint32_t)m_buffer.size ())
     m_buffer = m_reader.getBuffer (BUFFER_MAX_PROBE_LENGTH);
 
-  while (m_bufferPosition <= (uint32_t) m_buffer.size () || !m_reader.isEOS ()) {
+  while (m_bufferPosition <= (uint32_t)m_buffer.size () || !m_reader.isEOS ()) {
     pos = parseStream (m_bufferPosition);
-    if (pos == (int32_t) - 1) {
+    if (pos == (int32_t)-1) {
       return ESE_RESULT_NO_PACKET;
     } else {
       if (m_frameState == ESE_NAL_FRAME_STATE_END) {
         m_nextFrame = prepareFrame (m_buffer, m_frameStartPos, pos);
         m_nalCount++;
         DBG ("Found a new frame (%d) of size %zd at pos %d", m_nalCount,
-            m_nextFrame.size (), m_reader.filePosition () + m_frameStartPos);
+          m_nextFrame.size (), m_reader.filePosition () + m_frameStartPos);
         m_frameStartPos = pos;
         m_bufferPosition = pos;
         m_frameState = ESE_NAL_FRAME_STATE_NONE;
         return ESE_RESULT_NEW_PACKET;
       } else {
         m_bufferPosition = pos;
-        if (m_bufferPosition >= (uint32_t) m_buffer.size ()) {
+        if (m_bufferPosition >= (uint32_t)m_buffer.size ()) {
           if (m_reader.isEOS ()) {
-            m_nextFrame =
-                prepareFrame (m_buffer, m_frameStartPos, m_buffer.size ());
+            m_nextFrame = prepareFrame (m_buffer, m_frameStartPos, m_buffer.size ());
             m_nalCount++;
             DBG ("Found a last frame (%d) of size %zd at pos %d",
-                m_nalCount, m_nextFrame.size (),
-                m_reader.filePosition () + m_frameStartPos);
+              m_nalCount, m_nextFrame.size (),
+              m_reader.filePosition () + m_frameStartPos);
             m_eos = true;
             return ESE_RESULT_LAST_PACKET;
           } else {
@@ -178,18 +177,18 @@ ESENALStream::processToNextFrame ()
       prepareNextPacket ();
     }
   } else {
-    m_currentFrame = { };
+    m_currentFrame = {};
     while ((res = readStream ()) <= ESE_RESULT_EOS) {
-      if (!ese_is_aud_nalu (m_nextFrame, (ESENaluCodec) m_codec)) {
+      if (!ese_is_aud_nalu (m_nextFrame, (ESENaluCodec)m_codec)) {
         m_currentFrame.insert (m_currentFrame.end (), m_nextFrame.begin (),
-            m_nextFrame.end ());
+          m_nextFrame.end ());
       }
       if (res == ESE_RESULT_EOS
-          || ese_is_new_frame (m_nextFrame, (ESENaluCodec) m_codec)) {
+        || ese_is_new_frame (m_nextFrame, (ESENaluCodec)m_codec)) {
         if (m_currentFrame.size () > 0) {
-          const ESEBuffer & audNalu = ese_aud_nalu ((ESENaluCodec) m_codec);
+          const ESEBuffer &audNalu = ese_aud_nalu ((ESENaluCodec)m_codec);
           m_currentFrame.insert (m_currentFrame.begin (), audNalu.begin (),
-              audNalu.end ());
+            audNalu.end ());
           prepareNextPacket ();
         }
         break;

--- a/lib/esenalstream.h
+++ b/lib/esenalstream.h
@@ -26,45 +26,43 @@ typedef enum ESEPacketAlignment {
   ESE_PACKET_ALIGNMENT_AU,
 } ESEPacketAlignment;
 
-
 typedef enum _ESENALFrameState {
   ESE_NAL_FRAME_STATE_NONE = 0,
   ESE_NAL_FRAME_STATE_START,
   ESE_NAL_FRAME_STATE_END,
 } ESENALFrameState;
 
-
 class ESENALStream : public ESEStream {
 
-public:  
+  public:
   ESENALStream ();
   ~ESENALStream ();
 
-  virtual void reset();
+  virtual void reset ();
 
-  ESEResult processToNextFrame();
+  ESEResult processToNextFrame ();
   /// @brief Returns the NAL count.
   /// @return
-  int nalCount() { return m_nalCount;}
+  int nalCount () { return m_nalCount; }
   /// @brief Set frame format, either NAL or a complete access unit.
   /// @param alignment
 
-  void parseOptions(const char* options);
+  void parseOptions (const char *options);
 
-protected:
-  ESEBuffer getStartCode() {return { 0x00, 0x00, 0x00, 0x01 };}
+  protected:
+  ESEBuffer getStartCode () { return { 0x00, 0x00, 0x00, 0x01 }; }
 
-private:
-  ESEResult readStream ();
-  int32_t parseStream (int32_t start_position);
-  const char* alignmentName();
+  private:
+  ESEResult   readStream ();
+  int32_t     parseStream (int32_t start_position);
+  const char *alignmentName ();
 
-  ESENALFrameState            m_frameState;
-  int32_t                     m_frameStartPos;
-  uint32_t                    m_nalCount;
-  bool                        m_mpegDetected;
-  ESEBuffer                   m_nextNAL;
-  bool                        m_audNalDetected;
-  ESEPacketAlignment          m_alignment;
-  ESEBuffer                   m_nextFrame;
+  ESENALFrameState   m_frameState;
+  int32_t            m_frameStartPos;
+  uint32_t           m_nalCount;
+  bool               m_mpegDetected;
+  ESEBuffer          m_nextNAL;
+  bool               m_audNalDetected;
+  ESEPacketAlignment m_alignment;
+  ESEBuffer          m_nextFrame;
 };

--- a/lib/esenalu.cpp
+++ b/lib/esenalu.cpp
@@ -25,8 +25,8 @@ const ESEBuffer h264_aud_nalu = { 0x00, 0x00, 0x00, 0x01, 0x09, 0xF0 };
 const ESEBuffer h265_aud_nalu = { 0x00, 0x00, 0x00, 0x01, 0x46, 0x01, 0x10 };
 
 ESENalu::ESENalu (ESEBuffer buffer, ESENaluCodec codec)
-: m_buffer (buffer),
-m_naluCodec (codec)
+: m_buffer (buffer)
+, m_naluCodec (codec)
 {
 }
 
@@ -73,7 +73,6 @@ ESEH265Nalu::ESEH265Nalu (ESEBuffer buffer)
 {
   parseNalu ();
 }
-
 
 void
 ESEH265Nalu::parseNalu ()

--- a/lib/esenalu.h
+++ b/lib/esenalu.h
@@ -33,32 +33,30 @@ typedef enum ESENaluCodec {
   ESE_NALU_CODEC_H265,
 } ESENaluCodec;
 
-typedef enum
-{
-  ESE_H264_NAL_UNKNOWN      = 0,
-  ESE_H264_NAL_SLICE        = 1,
-  ESE_H264_NAL_SLICE_DPA    = 2,
-  ESE_H264_NAL_SLICE_DPB    = 3,
-  ESE_H264_NAL_SLICE_DPC    = 4,
-  ESE_H264_NAL_SLICE_IDR    = 5,
-  ESE_H264_NAL_SEI          = 6,
-  ESE_H264_NAL_SPS          = 7,
-  ESE_H264_NAL_PPS          = 8,
-  ESE_H264_NAL_AUD          = 9,
-  ESE_H264_NAL_SEQ_END      = 10,
-  ESE_H264_NAL_STREAM_END   = 11,
-  ESE_H264_NAL_FILLER_DATA  = 12,
-  ESE_H264_NAL_SPS_EXT      = 13,
-  ESE_H264_NAL_PREFIX_UNIT  = 14,
-  ESE_H264_NAL_SUBSET_SPS   = 15,
-  ESE_H264_NAL_DEPTH_SPS    = 16,
-  ESE_H264_NAL_SLICE_AUX    = 19,
-  ESE_H264_NAL_SLICE_EXT    = 20,
-  ESE_H264_NAL_SLICE_DEPTH  = 21
+typedef enum {
+  ESE_H264_NAL_UNKNOWN     = 0,
+  ESE_H264_NAL_SLICE       = 1,
+  ESE_H264_NAL_SLICE_DPA   = 2,
+  ESE_H264_NAL_SLICE_DPB   = 3,
+  ESE_H264_NAL_SLICE_DPC   = 4,
+  ESE_H264_NAL_SLICE_IDR   = 5,
+  ESE_H264_NAL_SEI         = 6,
+  ESE_H264_NAL_SPS         = 7,
+  ESE_H264_NAL_PPS         = 8,
+  ESE_H264_NAL_AUD         = 9,
+  ESE_H264_NAL_SEQ_END     = 10,
+  ESE_H264_NAL_STREAM_END  = 11,
+  ESE_H264_NAL_FILLER_DATA = 12,
+  ESE_H264_NAL_SPS_EXT     = 13,
+  ESE_H264_NAL_PREFIX_UNIT = 14,
+  ESE_H264_NAL_SUBSET_SPS  = 15,
+  ESE_H264_NAL_DEPTH_SPS   = 16,
+  ESE_H264_NAL_SLICE_AUX   = 19,
+  ESE_H264_NAL_SLICE_EXT   = 20,
+  ESE_H264_NAL_SLICE_DEPTH = 21
 } ESEH264NalUnitType;
 
-typedef enum
-{
+typedef enum {
   ESE_H265_NAL_SLICE_TRAIL_N    = 0,
   ESE_H265_NAL_SLICE_TRAIL_R    = 1,
   ESE_H265_NAL_SLICE_TSA_N      = 2,
@@ -86,55 +84,53 @@ typedef enum
   ESE_H265_NAL_SUFFIX_SEI       = 40
 } ESEH265NalUnitType;
 
-class ESENalu{
-public:
-  ESENalu(ESEBuffer  buffer, ESENaluCodec codec);
-  virtual ~ESENalu() {}
+class ESENalu {
+  public:
+  ESENalu (ESEBuffer buffer, ESENaluCodec codec);
+  virtual ~ESENalu () {}
 
-  int naluType() {return m_naluType;};
-  ESENaluCodec naluCodec() {return  m_naluCodec;}
-  ESENaluCategory naluCategory() {return m_naluCategory;};
+  int             naluType () { return m_naluType; };
+  ESENaluCodec    naluCodec () { return m_naluCodec; }
+  ESENaluCategory naluCategory () { return m_naluCategory; };
 
-protected:
-  virtual void parseNalu() = 0;
-  int                         m_naluType;
-  ESEBuffer   m_buffer;
-  ESENaluCodec               m_naluCodec;
-  ESENaluCategory            m_naluCategory;
-
+  protected:
+  virtual void    parseNalu () = 0;
+  int             m_naluType;
+  ESEBuffer       m_buffer;
+  ESENaluCodec    m_naluCodec;
+  ESENaluCategory m_naluCategory;
 };
 
-class ESEH264Nalu : public ESENalu{
-public:
-  ESEH264Nalu(ESEBuffer  buffer);
-  virtual ~ESEH264Nalu(){}
+class ESEH264Nalu : public ESENalu {
+  public:
+  ESEH264Nalu (ESEBuffer buffer);
+  virtual ~ESEH264Nalu () {}
 
-protected:
-
-  virtual void parseNalu() override;
-
+  protected:
+  virtual void parseNalu () override;
 };
 
 class ESEH265Nalu : public ESENalu {
-public:
-  ESEH265Nalu(ESEBuffer  buffer);
-  virtual ~ESEH265Nalu(){}
+  public:
+  ESEH265Nalu (ESEBuffer buffer);
+  virtual ~ESEH265Nalu () {}
 
-
-protected:
-
-  virtual void parseNalu() override;
-
+  protected:
+  virtual void parseNalu () override;
 };
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-bool ese_is_aud_nalu (ESEBuffer  buffer, ESENaluCodec codec);
-bool ese_is_new_frame (ESEBuffer  buffer, ESENaluCodec codec);
-ESENaluCategory ese_nalu_get_category (ESEBuffer buffer, ESENaluCodec codec);
-const ESEBuffer & ese_aud_nalu (ESENaluCodec codec);
+bool
+ese_is_aud_nalu (ESEBuffer buffer, ESENaluCodec codec);
+bool
+ese_is_new_frame (ESEBuffer buffer, ESENaluCodec codec);
+ESENaluCategory
+ese_nalu_get_category (ESEBuffer buffer, ESENaluCodec codec);
+const ESEBuffer &
+ese_aud_nalu (ESENaluCodec codec);
 #ifdef __cplusplus
 }
 #endif

--- a/lib/esereader.cpp
+++ b/lib/esereader.cpp
@@ -20,7 +20,6 @@
 
 #define BUFFER_MAX_PROBE_LENGTH (128 * 1024)
 
-
 ESEReader::ESEReader ()
 {
   reset ();
@@ -49,7 +48,7 @@ ESEReader::openFile (const char *fileName)
     return false;
 
   m_file = std::ifstream (fileName, std::ios::binary | std::ios::ate);
-  DBG ("The file %s is now %s", fileName, m_file.is_open ()? "open" : "closed");
+  DBG ("The file %s is now %s", fileName, m_file.is_open () ? "open" : "closed");
   if (m_file.is_open ()) {
     m_fileSize = m_file.tellg ();
     m_fileName = fileName;
@@ -60,8 +59,11 @@ ESEReader::openFile (const char *fileName)
   return false;
 }
 
-uint32_t ESEReader::readFile (int32_t data_size, int32_t pos, bool append)
+uint32_t
+ESEReader::readFile (int32_t data_size, int32_t pos, bool append)
 {
+  ESEBuffer buffer;
+  size_t read_size;
   if (!m_fileSize)
     m_fileSize = m_file.tellg ();
   if (!m_fileSize) {
@@ -70,23 +72,21 @@ uint32_t ESEReader::readFile (int32_t data_size, int32_t pos, bool append)
   }
 
   DBG ("Read %d at pos %d append %d from file size %d", data_size, pos, append,
-      m_fileSize);
+    m_fileSize);
   m_file.clear ();
   m_file.seekg (pos, m_file.beg);
   m_filePosition = pos;
-  ESEBuffer
-      buffer;
+
   buffer.resize (data_size);
-  m_file.read ((char *) buffer.data (), data_size);
-  size_t
-      read_size = m_file.gcount ();
+  m_file.read ((char *)buffer.data (), data_size);
+  read_size = m_file.gcount ();
   buffer.resize (read_size);
   m_readSize += read_size;
   m_filePosition += read_size;
   if (append) {
     m_buffer.insert (m_buffer.end (), buffer.begin (), buffer.end ());
     DBG ("ReadFile: Append %d to a buffer of new size %zd read %zd", data_size,
-        m_buffer.size (), read_size);
+      m_buffer.size (), read_size);
   } else {
     m_buffer = buffer;
     DBG ("ReadFile: Read buffer %d of size read %zd", data_size, read_size);
@@ -103,7 +103,8 @@ ESEReader::getBuffer (uint32_t size)
 
   while (m_buffer.size () < size) {
     if (readFile (BUFFER_MAX_PROBE_LENGTH, m_filePosition,
-            true) < BUFFER_MAX_PROBE_LENGTH)
+          true)
+      < BUFFER_MAX_PROBE_LENGTH)
       break;
   }
   if (m_buffer.size () < size)

--- a/lib/esereader.h
+++ b/lib/esereader.h
@@ -18,52 +18,50 @@
 #pragma once
 
 #include <cstdint>
-#include <iostream>
 #include <fstream>
+#include <iostream>
 #include <istream>
-#include <vector>
 #include <string>
+#include <vector>
 
-#define ESEBuffer std::vector <unsigned char>
+#define ESEBuffer std::vector<unsigned char>
 
-template < typename T > static inline std::vector <T>
-subVector (std::vector < T > const &v, int pos, int size)
+template<typename T> static inline std::vector<T>
+subVector (std::vector<T> const &v, int pos, int size)
 {
   auto first = v.cbegin () + pos;
-  auto last = v.cbegin () + pos + size;
+  auto last  = v.cbegin () + pos + size;
 
-  std::vector < T > vec (first, last);
+  std::vector<T> vec (first, last);
   return vec;
 }
 
 class ESEReader {
-public:
-  ESEReader();
-  ~ESEReader();
+  public:
+  ESEReader ();
+  ~ESEReader ();
   /// @brief This method will build the next frame (NAL or AU) available.
   /// @return
 
-  bool openFile(const char* fileName);
+  bool openFile (const char *fileName);
   /// @brief Reset the reader
   void reset (bool full = true);
   /// @brief Read data from file
   ESEBuffer getBuffer (uint32_t size);
-  int32_t readSize() { return m_readSize;}
-  int32_t fileSize() { return m_fileSize;}
-  int32_t filePosition() { return m_filePosition;}
+  int32_t   readSize () { return m_readSize; }
+  int32_t   fileSize () { return m_fileSize; }
+  int32_t   filePosition () { return m_filePosition; }
 
-  bool    isEOS () {return m_bufferSize == 0 && m_readSize == m_fileSize;}
+  bool isEOS () { return m_bufferSize == 0 && m_readSize == m_fileSize; }
 
-private:
-  uint32_t readFile(int32_t data_size, int32_t pos = 0, bool append = false );
+  private:
+  uint32_t readFile (int32_t data_size, int32_t pos = 0, bool append = false);
 
-  std::ifstream               m_file;
-  std::string                 m_fileName;
-  int32_t                     m_filePosition;
-  int32_t                     m_fileSize;
-
-  int32_t                     m_bufferSize;
-
-  int32_t                     m_readSize;
-  ESEBuffer                   m_buffer;
+  std::ifstream m_file;
+  std::string   m_fileName;
+  int32_t       m_filePosition;
+  int32_t       m_fileSize;
+  int32_t       m_bufferSize;
+  int32_t       m_readSize;
+  ESEBuffer     m_buffer;
 };

--- a/lib/esestream.cpp
+++ b/lib/esestream.cpp
@@ -19,11 +19,9 @@
 #include "eseivfstream.h"
 #include "eselogger.h"
 
-
 #define BUFFER_MAX_PROBE_LENGTH (128 * 1024)
 #define MPEG_HEADER_SIZE 3
 #define MAX_SEARCH_SIZE 5
-
 
 ESEVideoFormat
 ese_stream_probe_video_format (const char *uri)
@@ -41,10 +39,10 @@ ese_stream_probe_video_format (const char *uri)
   return format;
 }
 
-ESEStream::ESEStream (ESEVideoFormat format):
-m_format (format),
-m_currentPacket (nullptr),
-m_nextPacket (nullptr)
+ESEStream::ESEStream (ESEVideoFormat format)
+: m_format (format)
+, m_currentPacket (nullptr)
+, m_nextPacket (nullptr)
 {
   reset ();
 }
@@ -52,11 +50,11 @@ m_nextPacket (nullptr)
 ESEStream::~ESEStream ()
 {
   DBG ("Found %u frame and read %d of %d", m_frameCount, m_reader.readSize (),
-      m_reader.fileSize ());
+    m_reader.fileSize ());
 }
 
 void
-ESEStream::reset()
+ESEStream::reset ()
 {
   m_eos = false;
   m_bufferPosition = 0;
@@ -66,9 +64,9 @@ ESEStream::reset()
     delete m_nextPacket;
   m_nextPacket = nullptr;
   m_codec = ESE_VIDEO_CODEC_UNKNOWN;
-  m_buffer = ESEBuffer();
+  m_buffer = ESEBuffer ();
   m_currentFrame = ESEBuffer ();
-  m_reader.reset();
+  m_reader.reset ();
 }
 
 bool
@@ -77,30 +75,28 @@ ESEStream::prepare (const char *uri, const char *options)
   parseOptions (options);
   if (!m_reader.openFile (uri))
     return false;
-  return (processToNextFrame() <= ESE_RESULT_ERROR);
+  return (processToNextFrame () <= ESE_RESULT_ERROR);
 }
 
-void ESEStream::setOptions (const char *options)
+void
+ESEStream::setOptions (const char *options)
 {
   parseOptions (options);
 }
 
 ESEBuffer
 ESEStream::prepareFrame (ESEBuffer buffer, uint32_t start,
-    uint32_t end)
+  uint32_t end)
 {
   uint32_t frame_start = start;
   if (start > buffer.size () || end > buffer.size ()) {
-    throw
-        std::out_of_range
-        ("start and end positions must be within the buffer size");
+    throw std::out_of_range ("start and end positions must be within the buffer size");
   }
   if (start > end) {
-    throw
-        std::invalid_argument ("start position must be less than end position");
+    throw std::invalid_argument ("start position must be less than end position");
   }
   ESEBuffer frame = ESEBuffer (buffer.begin () + frame_start,
-      buffer.begin () + end);
+    buffer.begin () + end);
 
   ESEBuffer start_code = getStartCode ();
   frame.insert (frame.begin (), start_code.begin (), start_code.end ());
@@ -112,29 +108,30 @@ ESEPacket *
 ESEStream::prepareNextPacket (uint64_t pts, uint64_t dts, uint64_t duration)
 {
   m_nextPacket = new ESEPacket ();
-  m_nextPacket->data = static_cast<std::uint8_t*>(std::malloc(m_currentFrame.size ()));
+  m_nextPacket->data = static_cast<std::uint8_t *> (std::malloc (m_currentFrame.size ()));
   std::memcpy (m_nextPacket->data, m_currentFrame.data (), m_currentFrame.size ());
   m_nextPacket->data_size = m_currentFrame.size ();
   m_nextPacket->pts = pts;
   m_nextPacket->dts = dts;
   m_nextPacket->duration = duration;
-  m_frameCount ++;
+  m_frameCount++;
   return m_nextPacket;
 }
 
-ESEPacket* ESEStream::currentPacket()
+ESEPacket *
+ESEStream::currentPacket ()
 {
   m_currentPacket = m_nextPacket;
   m_nextPacket = nullptr;
   return m_currentPacket;
 }
 
-
-int32_t ESEStream::scanMPEGHeader (ESEBuffer buffer, int32_t pos)
+int32_t
+ESEStream::scanMPEGHeader (ESEBuffer buffer, int32_t pos)
 {
   for (uint32_t i = pos; i < buffer.size () - 3; i++) {
     bool found = (buffer[i] == 0x00 && buffer[i + 1] == 0x00
-        && buffer[i + 2] == 0x01);
+      && buffer[i + 2] == 0x01);
     if (found)
       return i;
   }
@@ -164,8 +161,7 @@ ESEStream::isH265 (ESEBuffer buffer)
   if ((buffer[3] & 0x01) || (buffer[4] & 0xf8) || !(buffer[4] & 0x07)) {
     found = false;
   }
-  if ((nut >= 0 && nut <= 9) || (nut >= 16 && nut <= 21) || (nut >= 32
-          && nut <= 40)) {
+  if ((nut >= 0 && nut <= 9) || (nut >= 16 && nut <= 21) || (nut >= 32 && nut <= 40)) {
     found = true;
   }
 
@@ -185,8 +181,8 @@ ESEStream::isH264 (ESEBuffer buffer)
   if (buffer.size () < MAX_SEARCH_SIZE)
     return found;
 
-  nut = buffer[0] & 0x9f;       /* forbiden_zero_bit | nal_unit_type */
-  ref = buffer[0] & 0x60;       /* nal_ref_idc */
+  nut = buffer[0] & 0x9f; /* forbiden_zero_bit | nal_unit_type */
+  ref = buffer[0] & 0x60; /* nal_ref_idc */
 
   /* if forbidden bit is different to 0 won't be h264 */
   if (nut > 0x1f) {
@@ -194,8 +190,7 @@ ESEStream::isH264 (ESEBuffer buffer)
   }
 
   if ((nut >= 1 && nut <= 13) || nut == 19) {
-    if ((nut == 5 && ref == 0) ||
-        ((nut == 6 || (nut >= 9 && nut <= 12)) && ref != 0)) {
+    if ((nut == 5 && ref == 0) || ((nut == 6 || (nut >= 9 && nut <= 12)) && ref != 0)) {
       found = false;
     } else {
       found = true;
@@ -214,11 +209,12 @@ ESEStream::isH264 (ESEBuffer buffer)
   return found;
 }
 
-int32_t ESEStream::probeH26x ()
+int32_t
+ESEStream::probeH26x ()
 {
   int32_t offset;
-  m_reader.reset();
-  m_buffer = m_reader.getBuffer(BUFFER_MAX_PROBE_LENGTH);
+  m_reader.reset ();
+  m_buffer = m_reader.getBuffer (BUFFER_MAX_PROBE_LENGTH);
 
   offset = scanMPEGHeader (m_buffer, 0);
   if (offset > 0) {
@@ -231,13 +227,14 @@ int32_t ESEStream::probeH26x ()
   return -1;
 }
 
-int32_t ESEStream::probeIVF ()
+int32_t
+ESEStream::probeIVF ()
 {
   IVFHeader ivf_header;
-  m_reader.reset();
-  m_buffer = m_reader.getBuffer(sizeof (IVFHeader));
-  std::memcpy (&ivf_header, m_buffer.data(), sizeof (IVFHeader));
-  if(ivf_header.signature == ESE_MAKE_FOURCC('D','K','I','F'))
+  m_reader.reset ();
+  m_buffer = m_reader.getBuffer (sizeof (IVFHeader));
+  std::memcpy (&ivf_header, m_buffer.data (), sizeof (IVFHeader));
+  if (ivf_header.signature == ESE_MAKE_FOURCC ('D', 'K', 'I', 'F'))
     return 0;
   return -1;
 }
@@ -248,7 +245,7 @@ ESEStream::parseOptions (const char *options)
   char *token;
   if (options == nullptr)
     return;
-  token = strtok ((char *) options, "\n");
+  token = strtok ((char *)options, "\n");
   while (token != NULL) {
     std::string s (token);
     size_t pos = s.find (":");

--- a/lib/esestream.h
+++ b/lib/esestream.h
@@ -20,66 +20,65 @@
 #include "esereader.h"
 #include "esextractor.h"
 
-#include <vector>
 #include <cstring>
-#include <string>
 #include <map>
+#include <string>
+#include <vector>
 
-#define ESE_MAKE_FOURCC(a,b,c,d) \
-  ( (uint32_t)(a) | ((uint32_t) (b)) << 8  | ((uint32_t) (c)) << 16 | ((uint32_t) (d)) << 24 )
+#define ESE_MAKE_FOURCC(a, b, c, d) \
+  ((uint32_t)(a) | ((uint32_t)(b)) << 8 | ((uint32_t)(c)) << 16 | ((uint32_t)(d)) << 24)
 
 #define BUFFER_MAX_PROBE_LENGTH (128 * 1024)
 
-ESEVideoFormat ese_stream_probe_video_format (const char* uri);
+ESEVideoFormat
+ese_stream_probe_video_format (const char *uri);
 
 class ESEStream {
-public:
+  public:
   ESEStream (ESEVideoFormat format = ESE_VIDEO_FORMAT_UNKNOWN);
   virtual ~ESEStream ();
 
-  virtual void reset();
+  virtual void reset ();
 
-  bool prepare (const char* uri, const char* options = nullptr);
-  void setOptions (const char *options);
-  virtual void parseOptions(const char* options);
+  bool         prepare (const char *uri, const char *options = nullptr);
+  void         setOptions (const char *options);
+  virtual void parseOptions (const char *options);
   /// @brief This method will build the next frame (NAL or AU) available.
   /// @return
-  virtual ESEResult processToNextFrame() {return ESE_RESULT_NO_PACKET;};
-  
+  virtual ESEResult processToNextFrame () { return ESE_RESULT_NO_PACKET; };
+
   int32_t scanMPEGHeader (ESEBuffer buffer, int32_t pos = 0);
   int32_t probeH26x ();
   int32_t probeIVF ();
-  bool isH264 (ESEBuffer buffer);
-  bool isH265 (ESEBuffer buffer);
+  bool    isH264 (ESEBuffer buffer);
+  bool    isH265 (ESEBuffer buffer);
 
-  ESEVideoCodec codec() { return m_codec;}
-  ESEVideoFormat format() { return m_format;}
-  ESEBuffer * currentFrame() { return &m_currentFrame;}
-  ESEPacket*                  currentPacket();
+  ESEVideoCodec  codec () { return m_codec; }
+  ESEVideoFormat format () { return m_format; }
+  ESEBuffer     *currentFrame () { return &m_currentFrame; }
+  ESEPacket     *currentPacket ();
 
   /// @brief Returns the frame count.
   /// @return
-  int frameCount() { return m_frameCount;}
+  int frameCount () { return m_frameCount; }
 
-protected:
-  ESEReader                   m_reader;
+  protected:
+  ESEReader m_reader;
 
-  virtual ESEBuffer  getStartCode() {return {};}
+  virtual ESEBuffer getStartCode () { return {}; }
 
   // Prepare the next frame available from the given buffer at given position.
-  ESEBuffer  prepareFrame(ESEBuffer  buffer, uint32_t start, uint32_t end);
-  ESEPacket* prepareNextPacket (uint64_t pts = 0, uint64_t dts = 0, uint64_t duration = 0);
+  ESEBuffer  prepareFrame (ESEBuffer buffer, uint32_t start, uint32_t end);
+  ESEPacket *prepareNextPacket (uint64_t pts = 0, uint64_t dts = 0, uint64_t duration = 0);
 
-  ESEVideoCodec                       m_codec;
-  ESEVideoFormat                      m_format;
-  std::map<std::string, std::string>  m_options;
-  
-  bool                                m_eos;
-  ESEBuffer                           m_buffer;
-  uint32_t                            m_bufferPosition;
-
-  ESEBuffer                           m_currentFrame;
-  uint32_t                            m_frameCount;
-  ESEPacket*                          m_currentPacket;
-  ESEPacket*                          m_nextPacket;
+  ESEVideoCodec                      m_codec;
+  ESEVideoFormat                     m_format;
+  std::map<std::string, std::string> m_options;
+  bool                               m_eos;
+  ESEBuffer                          m_buffer;
+  uint32_t                           m_bufferPosition;
+  ESEBuffer                          m_currentFrame;
+  uint32_t                           m_frameCount;
+  ESEPacket                         *m_currentPacket;
+  ESEPacket                         *m_nextPacket;
 };

--- a/lib/eseutils.h
+++ b/lib/eseutils.h
@@ -18,27 +18,26 @@
 #pragma once
 
 #if (__cplusplus < 201402L)
-#include <memory>
+#  include <memory>
 template<class T, class... Args>
-std::unique_ptr<T> make_unique(Args&&... args)
+std::unique_ptr<T>
+make_unique (Args &&...args)
 {
-    return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
+  return std::unique_ptr<T> (new T (std::forward<Args> (args)...));
 }
 #else
-# define make_unique std::make_unique
+#  define make_unique std::make_unique
 #endif
 
-#define ESE_CHECK(expr, val) \
-  if (expr) \
-    { } \
-  else {\
-    ERR ("Check '%s' fails", #expr);\
-    return val;\
+#define ESE_CHECK(expr, val)         \
+  if (expr) {                        \
+  } else {                           \
+    ERR ("Check '%s' fails", #expr); \
+    return val;                      \
   }
-#define ESE_CHECK_VOID(expr) \
-  if (expr) \
-   { } \
-   else { \
-     ERR ("Check '%s' fails", #expr);\
-    return;\
+#define ESE_CHECK_VOID(expr)         \
+  if (expr) {                        \
+  } else {                           \
+    ERR ("Check '%s' fails", #expr); \
+    return;                          \
   }

--- a/lib/esextractor.cpp
+++ b/lib/esextractor.cpp
@@ -17,17 +17,16 @@
 
 #include "esextractor.h"
 #include "eseivfstream.h"
-#include "esenalstream.h"
 #include "eselogger.h"
+#include "esenalstream.h"
 #include "eseutils.h"
-
 
 #include <cassert>
 
-
 struct ESExtractor {
 
-  ESExtractor () {
+  ESExtractor ()
+  {
   }
 
   ESEVideoFormat format ()
@@ -37,7 +36,7 @@ struct ESExtractor {
 
   ESEVideoCodec codec ()
   {
-      return m_stream->codec ();
+    return m_stream->codec ();
   }
 
   const char *codec_name ()
@@ -63,7 +62,7 @@ struct ESExtractor {
     return m_stream->frameCount ();
   }
 
-  ESEPacket * currentPacket ()
+  ESEPacket *currentPacket ()
   {
     return m_stream->currentPacket ();
   }
@@ -78,27 +77,25 @@ struct ESExtractor {
     ESEVideoFormat format = ese_stream_probe_video_format (uri);
     m_stream = nullptr;
     if (format == ESE_VIDEO_FORMAT_NAL) {
-      m_stream = make_unique<ESENALStream>();
+      m_stream = make_unique<ESENALStream> ();
     } else if (format == ESE_VIDEO_FORMAT_IVF) {
-      m_stream = make_unique<ESEIVFStream>();
+      m_stream = make_unique<ESEIVFStream> ();
     }
     if (m_stream && m_stream->prepare (uri, options)) {
-      return (m_stream->processToNextFrame()  <= ESE_RESULT_ERROR);
+      return (m_stream->processToNextFrame () <= ESE_RESULT_ERROR);
     }
     return false;
   }
 
   void setOptions (const char *options)
   {
-      m_stream->reset ();
-      m_stream->setOptions (options);
-      m_stream->processToNextFrame();
+    m_stream->reset ();
+    m_stream->setOptions (options);
+    m_stream->processToNextFrame ();
   }
 
   std::unique_ptr<ESEStream> m_stream;
 };
-
-//C API
 
 ESExtractor *
 es_extractor_new (const char *uri, const char *options)
@@ -112,19 +109,20 @@ es_extractor_new (const char *uri, const char *options)
   return NULL;
 }
 
-void es_extractor_set_options (ESExtractor * extractor, const char* options)
+void
+es_extractor_set_options (ESExtractor *extractor, const char *options)
 {
   ESE_CHECK_VOID (extractor != NULL);
   extractor->setOptions (options);
 }
 
 ESEResult
-es_extractor_read_packet (ESExtractor * extractor, ESEPacket ** packet)
+es_extractor_read_packet (ESExtractor *extractor, ESEPacket **packet)
 {
   ESE_CHECK (extractor != NULL, ESE_RESULT_ERROR);
   ESEResult res = ESE_RESULT_NEW_PACKET;
   res = extractor->processToNextPacket ();
-  if(res <  ESE_RESULT_EOS)
+  if (res < ESE_RESULT_EOS)
     *packet = extractor->currentPacket ();
   else
     *packet = nullptr;
@@ -133,35 +131,35 @@ es_extractor_read_packet (ESExtractor * extractor, ESEPacket ** packet)
 }
 
 ESEVideoCodec
-es_extractor_video_codec (ESExtractor * extractor)
+es_extractor_video_codec (ESExtractor *extractor)
 {
   ESE_CHECK (extractor != NULL, ESE_VIDEO_CODEC_UNKNOWN);
   return extractor->codec ();
 }
 
 ESEVideoFormat
-es_extractor_video_format (ESExtractor * extractor)
+es_extractor_video_format (ESExtractor *extractor)
 {
   ESE_CHECK (extractor != NULL, ESE_VIDEO_FORMAT_UNKNOWN);
   return extractor->format ();
 }
 
 const char *
-es_extractor_video_codec_name (ESExtractor * extractor)
+es_extractor_video_codec_name (ESExtractor *extractor)
 {
   ESE_CHECK (extractor != NULL, nullptr);
   return extractor->codec_name ();
 }
 
 int
-es_extractor_packet_count (ESExtractor * extractor)
+es_extractor_packet_count (ESExtractor *extractor)
 {
   ESE_CHECK (extractor != NULL, -1);
   return extractor->packetCount ();
 }
 
 void
-es_extractor_clear_packet (ESEPacket * pkt)
+es_extractor_clear_packet (ESEPacket *pkt)
 {
   if (pkt) {
     std::free (pkt->data);
@@ -170,7 +168,7 @@ es_extractor_clear_packet (ESEPacket * pkt)
 }
 
 void
-es_extractor_teardown (ESExtractor * extractor)
+es_extractor_teardown (ESExtractor *extractor)
 {
   ESE_CHECK_VOID (extractor != NULL);
   delete (extractor);

--- a/lib/esextractor.h
+++ b/lib/esextractor.h
@@ -34,38 +34,36 @@ typedef enum ESEVideoFormat {
   ESE_VIDEO_FORMAT_IVF,
 } ESEVideoFormat;
 
-typedef enum _ESEResult
-{
+typedef enum _ESEResult {
   /*< public >*/
   ESE_RESULT_NEW_PACKET = 0,
   ESE_RESULT_LAST_PACKET,
   ESE_RESULT_EOS,
-  ESE_RESULT_NO_PACKET ,
+  ESE_RESULT_NO_PACKET,
   ESE_RESULT_ERROR,
 } ESEResult;
 
 typedef struct _ESEPacket {
-    uint8_t * data;
-    int32_t data_size;
-    int32_t packet_number;
-    uint64_t pts;
-    uint64_t dts;
-    uint64_t duration;
+  uint8_t *data;
+  int32_t  data_size;
+  int32_t  packet_number;
+  uint64_t pts;
+  uint64_t dts;
+  uint64_t duration;
 } ESEPacket;
 
-
 #if (defined _WIN32 || defined __CYGWIN__) && !defined(ES_STATIC_COMPILATION)
-  #ifdef BUILDING_ES_EXTRACTOR
-    #define ES_EXTRACTOR_API __declspec(dllexport)
-  #else
-    #define ES_EXTRACTOR_API __declspec(dllimport)
-  #endif
+#  ifdef BUILDING_ES_EXTRACTOR
+#    define ES_EXTRACTOR_API __declspec(dllexport)
+#  else
+#    define ES_EXTRACTOR_API __declspec(dllimport)
+#  endif
 #else
-  #ifdef BUILDING_ES_EXTRACTOR
-      #define ES_EXTRACTOR_API __attribute__ ((visibility ("default")))
-  #else
-      #define ES_EXTRACTOR_API
-  #endif
+#  ifdef BUILDING_ES_EXTRACTOR
+#    define ES_EXTRACTOR_API __attribute__ ((visibility ("default")))
+#  else
+#    define ES_EXTRACTOR_API
+#  endif
 #endif
 
 struct ESExtractor;
@@ -75,34 +73,44 @@ extern "C" {
 #endif
 
 ES_EXTRACTOR_API
-ESExtractor * es_extractor_new (const char *uri, const char *options);
+ESExtractor *
+es_extractor_new (const char *uri, const char *options);
 
 ES_EXTRACTOR_API
-void es_extractor_set_options (ESExtractor *extractor, const char *options);
+void
+es_extractor_set_options (ESExtractor *extractor, const char *options);
 
 ES_EXTRACTOR_API
-ESEResult es_extractor_read_packet (ESExtractor *extractor, ESEPacket **pkt);
+ESEResult
+es_extractor_read_packet (ESExtractor *extractor, ESEPacket **pkt);
 
 ES_EXTRACTOR_API
-void es_extractor_clear_packet (ESEPacket *pkt);
+void
+es_extractor_clear_packet (ESEPacket *pkt);
 
 ES_EXTRACTOR_API
-ESEVideoFormat es_extractor_video_format(ESExtractor *extractor);
+ESEVideoFormat
+es_extractor_video_format (ESExtractor *extractor);
 
 ES_EXTRACTOR_API
-ESEVideoCodec es_extractor_video_codec(ESExtractor *extractor);
+ESEVideoCodec
+es_extractor_video_codec (ESExtractor *extractor);
 
 ES_EXTRACTOR_API
-const char* es_extractor_video_codec_name(ESExtractor *extractor);
+const char *
+es_extractor_video_codec_name (ESExtractor *extractor);
 
 ES_EXTRACTOR_API
-int es_extractor_packet_count (ESExtractor *extractor);
+int
+es_extractor_packet_count (ESExtractor *extractor);
 
 ES_EXTRACTOR_API
-void es_extractor_teardown (ESExtractor *extractor);
+void
+es_extractor_teardown (ESExtractor *extractor);
 
 ES_EXTRACTOR_API
-void es_extractor_set_log_level (uint8_t level);
+void
+es_extractor_set_log_level (uint8_t level);
 
 #ifdef __cplusplus
 }

--- a/meson.build
+++ b/meson.build
@@ -2,6 +2,7 @@ project('esextractor', 'c', 'cpp',
   default_options : [ 'buildtype=debug', 'cpp_std=c++11' ],
   version: '0.0.1'
 )
+python3 = import('python').find_installation()
 
 _override_options = []
 build_system = build_machine.system()
@@ -19,3 +20,11 @@ configure_file(output : 'config.h', configuration : cdata)
 
 subdir('lib')
 subdir('tests')
+
+clang_format = find_program('clang-format', required: false)
+# Install clang-format pre-commit hook
+if clang_format.found()
+  run_command(python3, '-c', 'import shutil; shutil.copy("scripts/git-hooks/multi-pre-commit.hook", ".git/hooks/pre-commit")', check: false)
+else
+  message('clang-format not found, please install it with your package manager to enable the commit message hook')
+endif

--- a/tests/testbin.cpp
+++ b/tests/testbin.cpp
@@ -22,36 +22,42 @@
 
 #include "testese.h"
 
-class CmdLineParser{
-    public:
-        CmdLineParser (int &argc, char **argv){
-            for (int i=1; i < argc; ++i)
-                this->tokens.push_back(std::string(argv[i]));
-        }
+class CmdLineParser {
+  public:
+  CmdLineParser (int &argc, char **argv)
+  {
+    for (int i = 1; i < argc; ++i)
+      this->tokens.push_back (std::string (argv[i]));
+  }
 
-        const std::string& getOption(const std::string &option) const{
-            std::vector<std::string>::const_iterator itr;
-            itr =  std::find(this->tokens.begin(), this->tokens.end(), option);
-            if (itr != this->tokens.end() && ++itr != this->tokens.end()){
-                return *itr;
-            }
-            static const std::string empty_string("");
-            return empty_string;
-        }
-        int optionExists(const std::string &option) const{
-            return std::count(this->tokens.begin(), this->tokens.end(), option);
-        }
-    private:
-        std::vector <std::string> tokens;
+  const std::string &getOption (const std::string &option) const
+  {
+    std::vector<std::string>::const_iterator itr;
+    itr = std::find (this->tokens.begin (), this->tokens.end (), option);
+    if (itr != this->tokens.end () && ++itr != this->tokens.end ()) {
+      return *itr;
+    }
+    static const std::string empty_string ("");
+    return empty_string;
+  }
+  int optionExists (const std::string &option) const
+  {
+    return std::count (this->tokens.begin (), this->tokens.end (), option);
+  }
+
+  private:
+  std::vector<std::string> tokens;
 };
 
-void usage(int argc, char *argv[]) {
+void
+usage (int argc, char *argv[])
+{
   std::cout << "Usage: " << argv[0] << " -f input_file" << std::endl;
   std::cout << std::endl;
-  std::cout << "Options: "<< std::endl;
-  std::cout << "-h:\t show this help message and exit"<< std::endl;
-  std::cout << "-o:\t add option to the parser cmd line"<< std::endl;
-  std::cout << "-d:\t increment the debug level which each occurences (ie -d -d = level info(2))"<< std::endl;
+  std::cout << "Options: " << std::endl;
+  std::cout << "-h:\t show this help message and exit" << std::endl;
+  std::cout << "-o:\t add option to the parser cmd line" << std::endl;
+  std::cout << "-d:\t increment the debug level which each occurences (ie -d -d = level info(2))" << std::endl;
 }
 
 int
@@ -61,24 +67,24 @@ main (int argc, char *argv[])
 
   std::ofstream myfile;
 
-  CmdLineParser cmdLine(argc, argv);
-  if(cmdLine.optionExists("-h")) {
-    usage(argc, argv);
+  CmdLineParser cmdLine (argc, argv);
+  if (cmdLine.optionExists ("-h")) {
+    usage (argc, argv);
     return 0;
   }
 
-  for (int i = 0; i < cmdLine.optionExists("-d"); i++){
-    debug ++;
+  for (int i = 0; i < cmdLine.optionExists ("-d"); i++) {
+    debug++;
   }
 
-  const std::string &option = cmdLine.getOption("-o");
+  const std::string &option = cmdLine.getOption ("-o");
 
-  const std::string &fileName = cmdLine.getOption("-f");
-  if (fileName.empty()){
+  const std::string &fileName = cmdLine.getOption ("-f");
+  if (fileName.empty ()) {
     std::cerr << "Error: No input file specified." << std::endl;
-    usage(argc, argv);
+    usage (argc, argv);
     return 1;
   }
 
-  return (int)(parse_file (fileName.c_str(), option.c_str(), debug) < 0);
+  return (int)(parse_file (fileName.c_str (), option.c_str (), debug) < 0);
 }

--- a/tests/testese.cpp
+++ b/tests/testese.cpp
@@ -15,16 +15,15 @@
  * permissions and limitations under the License.
  */
 
-#include <fstream>
 #include <algorithm>
 #include <cassert>
+#include <fstream>
 
-#include "esextractor.h"
 #include "eselogger.h"
-
+#include "esextractor.h"
 
 static void
-dump_packet (ESExtractor * esextractor, ESEPacket* pkt)
+dump_packet (ESExtractor *esextractor, ESEPacket *pkt)
 {
   const char *packet_type_name = es_extractor_video_codec_name (esextractor);
   INFO ("Got a %s packet of size %d pts=%lld", packet_type_name, pkt->data_size, pkt->pts);
@@ -36,28 +35,28 @@ dump_packet (ESExtractor * esextractor, ESEPacket* pkt)
 /// @param options Options used by the esextractor
 /// @param debug_level set the debug level of the esextractor
 /// @return a new esextractor object or nullptr if the path is not a valid media file.
-ESExtractor*
-create_es_extractor (const char *fileName, const char* options, uint8_t debug_level) {
+ESExtractor *
+create_es_extractor (const char *fileName, const char *options, uint8_t debug_level)
+{
   es_extractor_set_log_level (debug_level);
   INFO ("Extracting packets from %s with options %s", fileName, options);
   ESExtractor *esextractor = es_extractor_new (fileName, options);
   return esextractor;
 }
 
-
 /// @brief  Returns the number of frame found
 /// @param extractor a valid extractor
 /// @return the number of frames
 int
-parse (ESExtractor* esextractor)
+parse (ESExtractor *esextractor)
 {
   ESEResult res;
   ESEPacket *pkt;
   int packet_count;
 
-  while ((res =
-          es_extractor_read_packet (esextractor,
-              &pkt)) < ESE_RESULT_EOS) {
+  while ((res = es_extractor_read_packet (esextractor,
+            &pkt))
+    < ESE_RESULT_EOS) {
 
     dump_packet (esextractor, pkt);
     es_extractor_clear_packet (pkt);
@@ -68,13 +67,15 @@ parse (ESExtractor* esextractor)
   return packet_count;
 }
 
-int parse_file (const char *fileName, const char* options, uint8_t debug_level) {
-  ESExtractor* esextractor = create_es_extractor (fileName, options, debug_level);
+int
+parse_file (const char *fileName, const char *options, uint8_t debug_level)
+{
+  ESExtractor *esextractor = create_es_extractor (fileName, options, debug_level);
   if (!esextractor) {
     ERR ("Unable to discover a compatible stream. Exit");
     return -1;
   }
-  int packet_count = parse(esextractor);
+  int packet_count = parse (esextractor);
   es_extractor_teardown (esextractor);
   return packet_count;
 }

--- a/tests/testsuite.cpp
+++ b/tests/testsuite.cpp
@@ -22,34 +22,36 @@
 
 #include "testese.h"
 
-void check_nal_file(const char* uri, int log_level, ESEVideoCodec codec, std::string codec_name, int num_packets_nal, int num_packets_au)
+void
+check_nal_file (const char *uri, int log_level, ESEVideoCodec codec, std::string codec_name, int num_packets_nal, int num_packets_au)
 {
-  ESExtractor* extractor;
+  ESExtractor *extractor;
 
-  extractor = create_es_extractor(uri, nullptr, log_level);
-  assert(extractor);
-  assert(es_extractor_video_format(extractor) == ESE_VIDEO_FORMAT_NAL);
-  assert(es_extractor_video_codec(extractor) == codec);
-  assert(std::string(es_extractor_video_codec_name(extractor)) == codec_name);
-  assert(parse (extractor) == num_packets_nal);
+  extractor = create_es_extractor (uri, nullptr, log_level);
+  assert (extractor);
+  assert (es_extractor_video_format (extractor) == ESE_VIDEO_FORMAT_NAL);
+  assert (es_extractor_video_codec (extractor) == codec);
+  assert (std::string (es_extractor_video_codec_name (extractor)) == codec_name);
+  assert (parse (extractor) == num_packets_nal);
   es_extractor_set_options (extractor, "alignment:AU");
-  assert(parse (extractor) == num_packets_au);
+  assert (parse (extractor) == num_packets_au);
   es_extractor_set_options (extractor, "alignment:NAL");
-  assert(parse (extractor) == num_packets_nal);
-  es_extractor_teardown(extractor);
+  assert (parse (extractor) == num_packets_nal);
+  es_extractor_teardown (extractor);
 }
 
-void check_ivf_file (const char* uri, int log_level, ESEVideoCodec codec, std::string codec_name, int num_packets)
+void
+check_ivf_file (const char *uri, int log_level, ESEVideoCodec codec, std::string codec_name, int num_packets)
 {
-  ESExtractor* extractor;
+  ESExtractor *extractor;
 
-  extractor = create_es_extractor(uri, nullptr, log_level);
-  assert(extractor);
-  assert(es_extractor_video_format(extractor) == ESE_VIDEO_FORMAT_IVF);
-  assert(es_extractor_video_codec(extractor) == codec);
-  assert(std::string(es_extractor_video_codec_name(extractor)) == codec_name);
-  assert(parse (extractor) == num_packets);
-  es_extractor_teardown(extractor);
+  extractor = create_es_extractor (uri, nullptr, log_level);
+  assert (extractor);
+  assert (es_extractor_video_format (extractor) == ESE_VIDEO_FORMAT_IVF);
+  assert (es_extractor_video_codec (extractor) == codec);
+  assert (std::string (es_extractor_video_codec_name (extractor)) == codec_name);
+  assert (parse (extractor) == num_packets);
+  es_extractor_teardown (extractor);
 }
 
 int
@@ -57,21 +59,21 @@ main (int argc, char *argv[])
 {
   int log_level = ES_LOG_LEVEL_INFO;
 
-  check_nal_file(ESE_SAMPLES_FOLDER "/Sample_10.avc", log_level, ESE_VIDEO_CODEC_H264, "h264", 22, 10);
-  check_nal_file(ESE_SAMPLES_FOLDER "/Sample_10.hevc", log_level, ESE_VIDEO_CODEC_H265, "h265", 23, 10);
+  check_nal_file (ESE_SAMPLES_FOLDER "/Sample_10.avc", log_level, ESE_VIDEO_CODEC_H264, "h264", 22, 10);
+  check_nal_file (ESE_SAMPLES_FOLDER "/Sample_10.hevc", log_level, ESE_VIDEO_CODEC_H265, "h265", 23, 10);
 
   // IVF tests
   check_ivf_file (ESE_SAMPLES_FOLDER "/clip-a.ivf", log_level, ESE_VIDEO_CODEC_AV1, "av1", 30);
 
   // Corner case tests
-  assert(parse_file (nullptr, nullptr, log_level) == -1);
-  assert(parse_file ("/this/path/does/not/exists", nullptr, log_level) == -1);
+  assert (parse_file (nullptr, nullptr, log_level) == -1);
+  assert (parse_file ("/this/path/does/not/exists", nullptr, log_level) == -1);
 
-  assert(es_extractor_read_packet(nullptr, nullptr) == ESE_RESULT_ERROR);
-  assert(es_extractor_packet_count(nullptr) == -1);
-  assert(es_extractor_video_format(nullptr) == ESE_VIDEO_FORMAT_UNKNOWN);
-  assert(es_extractor_video_codec(nullptr) == ESE_VIDEO_CODEC_UNKNOWN);
-  assert(es_extractor_video_codec_name(nullptr) == nullptr);
+  assert (es_extractor_read_packet (nullptr, nullptr) == ESE_RESULT_ERROR);
+  assert (es_extractor_packet_count (nullptr) == -1);
+  assert (es_extractor_video_format (nullptr) == ESE_VIDEO_FORMAT_UNKNOWN);
+  assert (es_extractor_video_codec (nullptr) == ESE_VIDEO_CODEC_UNKNOWN);
+  assert (es_extractor_video_codec_name (nullptr) == nullptr);
 
   return 0;
 }


### PR DESCRIPTION
The .clang-format comes from webkit project
and has been adapted to copycat GStreamer
coding style.