### PR TITLE
ESEDataProvider: add new reader to offer a custom data provider to ESExtractor

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,6 +1,7 @@
 ---
 BasedOnStyle:  WebKit
-
+AlignConsecutiveDeclarations: true
+AlignConsecutiveAssignments: true
 AlwaysBreakAfterReturnType: TopLevel
 ConstructorInitializerIndentWidth: 0
 ContinuationIndentWidth: 2

--- a/lib/esedatareader.cpp
+++ b/lib/esedatareader.cpp
@@ -1,5 +1,5 @@
 /* ESExtractor
- * Copyright (C) 2022 Igalia, S.L.
+ * Copyright (C) 2023 Igalia, S.L.
  *     Author: Stephane Cerveau <scerveau@igalia.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you
@@ -15,24 +15,37 @@
  * permissions and limitations under the License.
  */
 
-#include "esereader.h"
-#include "eselogger.h"
-#include "eseutils.h"
+#include "esedatareader.h"
 
-ESEReader::ESEReader ()
+ESEDataReader::ESEDataReader (ese_read_buffer_func read_func, void *pointer)
 {
+  m_readFunc    = read_func;
+  m_dataPointer = pointer;
   reset ();
 }
 
-ESEReader::~ESEReader ()
+ESEDataReader::~ESEDataReader ()
 {
 }
 
-void
-ESEReader::reset (bool full)
+bool
+ESEDataReader::prepare ()
 {
-  m_streamPosition = 0;
-  m_bufferSize     = 0;
-  m_readSize       = 0;
-  m_buffer         = ESEBuffer ();
+  return true;
+}
+
+ESEBuffer
+ESEDataReader::getBuffer (uint32_t size)
+{
+  ESEBuffer buffer;
+
+  if (!m_readFunc)
+    return ESEBuffer ();
+
+  buffer.resize (size);
+  uint32_t read_size = m_readFunc (m_dataPointer, buffer.data (), size, m_streamPosition);
+  if (read_size < size)
+    buffer.resize (read_size);
+
+  return buffer;
 }

--- a/lib/esedatareader.h
+++ b/lib/esedatareader.h
@@ -15,24 +15,21 @@
  * permissions and limitations under the License.
  */
 
+#pragma once
+
 #include "esereader.h"
-#include "eselogger.h"
 #include "eseutils.h"
+#include "esextractor.h"
 
-ESEReader::ESEReader ()
-{
-  reset ();
-}
+class ESEDataReader : public ESEReader {
+  public:
+  ESEDataReader (ese_read_buffer_func read_func, void *pointer);
+  ~ESEDataReader ();
 
-ESEReader::~ESEReader ()
-{
-}
+  bool              prepare ();
+  virtual ESEBuffer getBuffer (uint32_t size);
 
-void
-ESEReader::reset (bool full)
-{
-  m_streamPosition = 0;
-  m_bufferSize     = 0;
-  m_readSize       = 0;
-  m_buffer         = ESEBuffer ();
-}
+  private:
+  ese_read_buffer_func m_readFunc;
+  void                *m_dataPointer;
+};

--- a/lib/esefilereader.cpp
+++ b/lib/esefilereader.cpp
@@ -1,0 +1,102 @@
+/* ESExtractor
+ * Copyright (C) 2023 Igalia, S.L.
+ *     Author: Stephane Cerveau <scerveau@igalia.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You
+ * may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+#include "esefilereader.h"
+
+ESEFileReader::ESEFileReader (const char *fileName)
+{
+  if (fileName)
+    m_fileName = fileName;
+  reset ();
+}
+
+bool
+ESEFileReader::prepare ()
+{
+  if (m_file.is_open ())
+    return true;
+
+  if (m_fileName.empty ())
+    return false;
+
+  m_file = std::ifstream (m_fileName, std::ios::binary | std::ios::ate);
+  DBG ("The file %s is now %s", m_fileName.c_str (), m_file.is_open () ? "open" : "closed");
+  m_fileSize = m_file.tellg ();
+  if (!m_file.is_open () || m_fileSize <= 0) {
+    ERR ("Unable to open the file %s", m_fileName.c_str ());
+    return false;
+  }
+
+  return true;
+}
+
+uint32_t
+ESEFileReader::readFile (int32_t data_size, int32_t pos, bool append)
+{
+  ESEBuffer buffer;
+  size_t    read_size;
+
+  if (!m_fileSize)
+    m_fileSize = m_file.tellg ();
+  if (m_fileSize <= 0) {
+    ERR ("The file is empty. Exit.");
+    return 0;
+  }
+
+  DBG ("Read %d at pos %d append %d from file size %d", data_size, pos, append,
+    m_fileSize);
+  m_file.clear ();
+  m_file.seekg (pos, m_file.beg);
+  m_streamPosition = pos;
+
+  buffer.resize (data_size);
+  m_file.read ((char *)buffer.data (), data_size);
+  read_size = m_file.gcount ();
+  buffer.resize (read_size);
+  m_readSize += read_size;
+  m_streamPosition += read_size;
+  if (append) {
+    m_buffer.insert (m_buffer.end (), buffer.begin (), buffer.end ());
+    DBG ("ReadFile: Append %d to a buffer of new size %zd read %zd", data_size,
+      m_buffer.size (), read_size);
+  } else {
+    m_buffer = buffer;
+    DBG ("ReadFile: Read buffer %d of size read %zd", data_size, read_size);
+  }
+  m_bufferSize = m_buffer.size ();
+  return read_size;
+}
+
+ESEBuffer
+ESEFileReader::getBuffer (uint32_t size)
+{
+  uint32_t  real_size = size;
+  ESEBuffer buffer;
+
+  while (m_buffer.size () < size) {
+    if (readFile (BUFFER_MAX_PROBE_LENGTH, m_streamPosition,
+          true)
+      < BUFFER_MAX_PROBE_LENGTH)
+      break;
+  }
+  if (m_buffer.size () < size)
+    real_size = m_buffer.size ();
+
+  buffer = subVector (m_buffer, 0, real_size);
+  m_buffer.erase (m_buffer.begin (), m_buffer.begin () + real_size);
+  m_bufferSize = m_buffer.size ();
+  return buffer;
+}

--- a/lib/esefilereader.h
+++ b/lib/esefilereader.h
@@ -24,9 +24,8 @@
 #include <string>
 #include <vector>
 
-#include "eseutils.h"
 #include "esereader.h"
-
+#include "eseutils.h"
 
 class ESEFileReader : public ESEReader {
   public:

--- a/lib/esefilereader.h
+++ b/lib/esefilereader.h
@@ -15,24 +15,32 @@
  * permissions and limitations under the License.
  */
 
-#include "eselogger.h"
-#include "esereader.h"
+#pragma once
+
+#include <cstdint>
+#include <fstream>
+#include <iostream>
+#include <istream>
+#include <string>
+#include <vector>
+
 #include "eseutils.h"
+#include "esereader.h"
 
-ESEReader::ESEReader ()
-{
-  reset ();
-}
 
-ESEReader::~ESEReader ()
-{
-}
+class ESEFileReader : public ESEReader {
+  public:
+  ESEFileReader (const char *fileName);
 
-void
-ESEReader::reset (bool full)
-{
-  m_streamPosition = 0;
-  m_bufferSize     = 0;
-  m_readSize       = 0;
-  m_buffer         = ESEBuffer ();
-}
+  virtual bool prepare ();
+
+  virtual ESEBuffer getBuffer (uint32_t size);
+  virtual int32_t   streamSize () { return m_fileSize; }
+
+  private:
+  uint32_t readFile (int32_t data_size, int32_t pos = 0, bool append = false);
+
+  std::ifstream m_file;
+  std::string   m_fileName;
+  int32_t       m_fileSize;
+};

--- a/lib/eseivfstream.cpp
+++ b/lib/eseivfstream.cpp
@@ -43,7 +43,7 @@ void
 ESEIVFStream::reset ()
 {
   m_headerFound = false;
-  m_lastPts = 0;
+  m_lastPts     = 0;
   ESEStream::reset ();
 }
 
@@ -75,7 +75,7 @@ ESEIVFStream::fourccToCodec ()
 ESEResult
 ESEIVFStream::processToNextFrame ()
 {
-  ESEResult res = ESE_RESULT_NEW_PACKET;
+  ESEResult      res = ESE_RESULT_NEW_PACKET;
   IVFFrameHeader frame_header;
 
   if (m_nextPacket)
@@ -88,13 +88,13 @@ ESEIVFStream::processToNextFrame ()
     m_buffer = m_reader->getBuffer (sizeof (IVFHeader));
     std::memcpy (&m_header, m_buffer.data (), sizeof (IVFHeader));
     m_headerFound = true;
-    m_codec = fourccToCodec ();
+    m_codec       = fourccToCodec ();
   }
   m_buffer = m_reader->getBuffer (sizeof (IVFFrameHeader));
 
   std::memcpy (&frame_header, m_buffer.data (), sizeof (IVFFrameHeader));
 
-  m_buffer = m_reader->getBuffer (frame_header.frame_size);
+  m_buffer       = m_reader->getBuffer (frame_header.frame_size);
   m_currentFrame = prepareFrame (m_buffer, 0, m_buffer.size ());
 
   prepareNextPacket (frame_header.timestamp, frame_header.timestamp,

--- a/lib/eseivfstream.cpp
+++ b/lib/eseivfstream.cpp
@@ -81,20 +81,20 @@ ESEIVFStream::processToNextFrame ()
   if (m_nextPacket)
     return ESE_RESULT_NEW_PACKET;
 
-  if (m_reader.isEOS ())
+  if (m_reader->isEOS ())
     return ESE_RESULT_EOS;
 
   if (!m_headerFound) {
-    m_buffer = m_reader.getBuffer (sizeof (IVFHeader));
+    m_buffer = m_reader->getBuffer (sizeof (IVFHeader));
     std::memcpy (&m_header, m_buffer.data (), sizeof (IVFHeader));
     m_headerFound = true;
     m_codec = fourccToCodec ();
   }
-  m_buffer = m_reader.getBuffer (sizeof (IVFFrameHeader));
+  m_buffer = m_reader->getBuffer (sizeof (IVFFrameHeader));
 
   std::memcpy (&frame_header, m_buffer.data (), sizeof (IVFFrameHeader));
 
-  m_buffer = m_reader.getBuffer (frame_header.frame_size);
+  m_buffer = m_reader->getBuffer (frame_header.frame_size);
   m_currentFrame = prepareFrame (m_buffer, 0, m_buffer.size ());
 
   prepareNextPacket (frame_header.timestamp, frame_header.timestamp,
@@ -102,7 +102,7 @@ ESEIVFStream::processToNextFrame ()
 
   m_lastPts = frame_header.timestamp;
 
-  if (m_reader.isEOS ())
+  if (m_reader->isEOS ())
     res = ESE_RESULT_LAST_PACKET;
 
   DBG ("Found a new IVF frame (%d) of size %zd", m_frameCount,

--- a/lib/esenalstream.cpp
+++ b/lib/esenalstream.cpp
@@ -36,14 +36,14 @@ ESENALStream::~ESENALStream ()
 void
 ESENALStream::reset ()
 {
-  m_frameState = ESE_NAL_FRAME_STATE_NONE;
-  m_frameStartPos = 0;
-  m_nalCount = false;
-  m_mpegDetected = false;
+  m_frameState     = ESE_NAL_FRAME_STATE_NONE;
+  m_frameStartPos  = 0;
+  m_nalCount       = false;
+  m_mpegDetected   = false;
   m_audNalDetected = false;
-  m_alignment = ESE_PACKET_ALIGNMENT_NAL;
-  m_nextNAL = ESEBuffer ();
-  m_nextFrame = ESEBuffer ();
+  m_alignment      = ESE_PACKET_ALIGNMENT_NAL;
+  m_nextNAL        = ESEBuffer ();
+  m_nextFrame      = ESEBuffer ();
   ESEStream::reset ();
 }
 
@@ -73,7 +73,7 @@ ESENALStream::parseOptions (const char *options)
 int32_t
 ESENALStream::parseStream (int32_t start_position)
 {
-  int32_t pos = start_position;
+  int32_t pos         = start_position;
   int32_t buffer_size = m_buffer.size ();
 
   while (pos < buffer_size) {
@@ -82,8 +82,8 @@ ESENALStream::parseStream (int32_t start_position)
       if (pos > 0) {
         /* start code might have 2 or 3 0-bytes */
         m_frameStartPos = pos;
-        m_frameState = ESE_NAL_FRAME_STATE_START;
-        m_mpegDetected = true;
+        m_frameState    = ESE_NAL_FRAME_STATE_START;
+        m_mpegDetected  = true;
       } else {
         ERR ("Unable to find any start code in buffer size %d. Exit.",
           buffer_size);
@@ -136,9 +136,9 @@ ESENALStream::readStream ()
         m_nalCount++;
         DBG ("Found a new frame (%d) of size %zd at pos %d", m_nalCount,
           m_nextFrame.size (), m_reader->streamPosition () + m_frameStartPos);
-        m_frameStartPos = pos;
+        m_frameStartPos  = pos;
         m_bufferPosition = pos;
-        m_frameState = ESE_NAL_FRAME_STATE_NONE;
+        m_frameState     = ESE_NAL_FRAME_STATE_NONE;
         return ESE_RESULT_NEW_PACKET;
       } else {
         m_bufferPosition = pos;

--- a/lib/esenalstream.cpp
+++ b/lib/esenalstream.cpp
@@ -124,9 +124,9 @@ ESENALStream::readStream ()
   }
 
   if (m_bufferPosition >= (uint32_t)m_buffer.size ())
-    m_buffer = m_reader.getBuffer (BUFFER_MAX_PROBE_LENGTH);
+    m_buffer = m_reader->getBuffer (BUFFER_MAX_PROBE_LENGTH);
 
-  while (m_bufferPosition <= (uint32_t)m_buffer.size () || !m_reader.isEOS ()) {
+  while (m_bufferPosition <= (uint32_t)m_buffer.size () || !m_reader->isEOS ()) {
     pos = parseStream (m_bufferPosition);
     if (pos == (int32_t)-1) {
       return ESE_RESULT_NO_PACKET;
@@ -135,7 +135,7 @@ ESENALStream::readStream ()
         m_nextFrame = prepareFrame (m_buffer, m_frameStartPos, pos);
         m_nalCount++;
         DBG ("Found a new frame (%d) of size %zd at pos %d", m_nalCount,
-          m_nextFrame.size (), m_reader.filePosition () + m_frameStartPos);
+          m_nextFrame.size (), m_reader->streamPosition () + m_frameStartPos);
         m_frameStartPos = pos;
         m_bufferPosition = pos;
         m_frameState = ESE_NAL_FRAME_STATE_NONE;
@@ -143,16 +143,16 @@ ESENALStream::readStream ()
       } else {
         m_bufferPosition = pos;
         if (m_bufferPosition >= (uint32_t)m_buffer.size ()) {
-          if (m_reader.isEOS ()) {
+          if (m_reader->isEOS ()) {
             m_nextFrame = prepareFrame (m_buffer, m_frameStartPos, m_buffer.size ());
             m_nalCount++;
             DBG ("Found a last frame (%d) of size %zd at pos %d",
               m_nalCount, m_nextFrame.size (),
-              m_reader.filePosition () + m_frameStartPos);
+              m_reader->streamPosition () + m_frameStartPos);
             m_eos = true;
             return ESE_RESULT_LAST_PACKET;
           } else {
-            ESEBuffer buffer = m_reader.getBuffer (BUFFER_MAX_PROBE_LENGTH);
+            ESEBuffer buffer = m_reader->getBuffer (BUFFER_MAX_PROBE_LENGTH);
             m_buffer.insert (m_buffer.end (), buffer.begin (), buffer.end ());
           }
         }

--- a/lib/esenalu.cpp
+++ b/lib/esenalu.cpp
@@ -129,8 +129,8 @@ getNalu (ESEBuffer buffer, ESENaluCodec codec)
 ESENaluCategory
 ese_nalu_get_category (ESEBuffer buffer, ESENaluCodec codec)
 {
-  ESENaluCategory cat = ESE_NALU_CATEGORY_UNKNOWN;
-  ESENalu *nalu = getNalu (buffer, codec);
+  ESENaluCategory cat  = ESE_NALU_CATEGORY_UNKNOWN;
+  ESENalu        *nalu = getNalu (buffer, codec);
   if (nalu) {
     cat = nalu->naluCategory ();
     delete nalu;

--- a/lib/esenalu.cpp
+++ b/lib/esenalu.cpp
@@ -16,7 +16,7 @@
  */
 
 #include "esenalu.h"
-#include "esestream.h"
+#include "eseutils.h"
 
 const int NAL_UNIT_TYPE_MASK = 0x1F;
 

--- a/lib/esenalu.h
+++ b/lib/esenalu.h
@@ -87,7 +87,7 @@ typedef enum {
 class ESENalu {
   public:
   ESENalu (ESEBuffer buffer, ESENaluCodec codec);
-  virtual ~ESENalu () {}
+  virtual ~ESENalu () { }
 
   int             naluType () { return m_naluType; };
   ESENaluCodec    naluCodec () { return m_naluCodec; }
@@ -104,7 +104,7 @@ class ESENalu {
 class ESEH264Nalu : public ESENalu {
   public:
   ESEH264Nalu (ESEBuffer buffer);
-  virtual ~ESEH264Nalu () {}
+  virtual ~ESEH264Nalu () { }
 
   protected:
   virtual void parseNalu () override;
@@ -113,7 +113,7 @@ class ESEH264Nalu : public ESENalu {
 class ESEH265Nalu : public ESENalu {
   public:
   ESEH265Nalu (ESEBuffer buffer);
-  virtual ~ESEH265Nalu () {}
+  virtual ~ESEH265Nalu () { }
 
   protected:
   virtual void parseNalu () override;

--- a/lib/esereader.h
+++ b/lib/esereader.h
@@ -17,51 +17,32 @@
 
 #pragma once
 
-#include <cstdint>
-#include <fstream>
-#include <iostream>
-#include <istream>
-#include <string>
-#include <vector>
 
-#define ESEBuffer std::vector<unsigned char>
 
-template<typename T> static inline std::vector<T>
-subVector (std::vector<T> const &v, int pos, int size)
-{
-  auto first = v.cbegin () + pos;
-  auto last  = v.cbegin () + pos + size;
+#include "eselogger.h"
+#include "eseutils.h"
 
-  std::vector<T> vec (first, last);
-  return vec;
-}
+#define BUFFER_MAX_PROBE_LENGTH (128 * 1024)
 
 class ESEReader {
   public:
   ESEReader ();
-  ~ESEReader ();
-  /// @brief This method will build the next frame (NAL or AU) available.
-  /// @return
-
-  bool openFile (const char *fileName);
+  virtual ~ESEReader ();
   /// @brief Reset the reader
-  void reset (bool full = true);
-  /// @brief Read data from file
-  ESEBuffer getBuffer (uint32_t size);
-  int32_t   readSize () { return m_readSize; }
-  int32_t   fileSize () { return m_fileSize; }
-  int32_t   filePosition () { return m_filePosition; }
+  virtual void reset (bool full = true);
 
-  bool isEOS () { return m_bufferSize == 0 && m_readSize == m_fileSize; }
+  virtual bool      prepare () { return true; }
+  virtual ESEBuffer getBuffer (uint32_t size) = 0;
 
-  private:
-  uint32_t readFile (int32_t data_size, int32_t pos = 0, bool append = false);
+  int32_t         readSize () { return m_readSize; }
+  virtual int32_t streamSize () { return 0; }
+  int32_t         streamPosition () { return m_streamPosition; }
 
-  std::ifstream m_file;
-  std::string   m_fileName;
-  int32_t       m_filePosition;
-  int32_t       m_fileSize;
-  int32_t       m_bufferSize;
-  int32_t       m_readSize;
-  ESEBuffer     m_buffer;
+  bool isEOS () { return m_bufferSize == 0 && m_readSize == streamSize (); }
+
+  protected:
+  int32_t   m_streamPosition;
+  int32_t   m_bufferSize;
+  int32_t   m_readSize;
+  ESEBuffer m_buffer;
 };

--- a/lib/esereader.h
+++ b/lib/esereader.h
@@ -17,10 +17,9 @@
 
 #pragma once
 
-
-
 #include "eselogger.h"
 #include "eseutils.h"
+#include "esextractor.h"
 
 #define BUFFER_MAX_PROBE_LENGTH (128 * 1024)
 

--- a/lib/esestream.h
+++ b/lib/esestream.h
@@ -17,18 +17,17 @@
 
 #pragma once
 
-#include "esereader.h"
-#include "esextractor.h"
-
 #include <cstring>
 #include <map>
 #include <string>
 #include <vector>
+#include <memory>
+
+#include "esereader.h"
+#include "esextractor.h"
 
 #define ESE_MAKE_FOURCC(a, b, c, d) \
   ((uint32_t)(a) | ((uint32_t)(b)) << 8 | ((uint32_t)(c)) << 16 | ((uint32_t)(d)) << 24)
-
-#define BUFFER_MAX_PROBE_LENGTH (128 * 1024)
 
 ESEVideoFormat
 ese_stream_probe_video_format (const char *uri);
@@ -63,7 +62,7 @@ class ESEStream {
   int frameCount () { return m_frameCount; }
 
   protected:
-  ESEReader m_reader;
+  std::unique_ptr<ESEReader> m_reader;
 
   virtual ESEBuffer getStartCode () { return {}; }
 

--- a/lib/esestream.h
+++ b/lib/esestream.h
@@ -19,18 +19,15 @@
 
 #include <cstring>
 #include <map>
+#include <memory>
 #include <string>
 #include <vector>
-#include <memory>
 
-#include "esereader.h"
+#include "esedatareader.h"
 #include "esextractor.h"
 
 #define ESE_MAKE_FOURCC(a, b, c, d) \
   ((uint32_t)(a) | ((uint32_t)(b)) << 8 | ((uint32_t)(c)) << 16 | ((uint32_t)(d)) << 24)
-
-ESEVideoFormat
-ese_stream_probe_video_format (const char *uri);
 
 class ESEStream {
   public:
@@ -40,6 +37,7 @@ class ESEStream {
   virtual void reset ();
 
   bool         prepare (const char *uri, const char *options = nullptr);
+  bool         prepare (ese_read_buffer_func func, void *pointer, const char *options);
   void         setOptions (const char *options);
   virtual void parseOptions (const char *options);
   /// @brief This method will build the next frame (NAL or AU) available.
@@ -81,3 +79,6 @@ class ESEStream {
   ESEPacket                         *m_currentPacket;
   ESEPacket                         *m_nextPacket;
 };
+
+ESEVideoFormat
+ese_stream_probe_video_format (ESEStream *stream);

--- a/lib/eseutils.h
+++ b/lib/eseutils.h
@@ -17,6 +17,9 @@
 
 #pragma once
 
+#include <vector>
+#include <cstdint>
+
 #if (__cplusplus < 201402L)
 #  include <memory>
 template<class T, class... Args>
@@ -41,3 +44,15 @@ make_unique (Args &&...args)
     ERR ("Check '%s' fails", #expr); \
     return;                          \
   }
+
+#define ESEBuffer std::vector<unsigned char>
+
+template<typename T> static inline std::vector<T>
+subVector (std::vector<T> const &v, int pos, int size)
+{
+  auto first = v.cbegin () + pos;
+  auto last  = v.cbegin () + pos + size;
+
+  std::vector<T> vec (first, last);
+  return vec;
+}

--- a/lib/eseutils.h
+++ b/lib/eseutils.h
@@ -17,12 +17,12 @@
 
 #pragma once
 
-#include <vector>
 #include <cstdint>
+#include <vector>
 
 #if (__cplusplus < 201402L)
 #  include <memory>
-template<class T, class... Args>
+template <class T, class... Args>
 std::unique_ptr<T>
 make_unique (Args &&...args)
 {
@@ -45,9 +45,8 @@ make_unique (Args &&...args)
     return;                          \
   }
 
-#define ESEBuffer std::vector<unsigned char>
-
-template<typename T> static inline std::vector<T>
+template <typename T>
+static inline std::vector<T>
 subVector (std::vector<T> const &v, int pos, int size)
 {
   auto first = v.cbegin () + pos;

--- a/lib/esextractor.h
+++ b/lib/esextractor.h
@@ -19,6 +19,9 @@
 
 #include <cstdint>
 
+typedef int32_t (*ese_read_buffer_func) (void *opaque, unsigned char *buffer, int32_t buffer_size, int32_t offset);
+#define ESEBuffer std::vector<unsigned char>
+
 typedef enum ESEVideoCodec {
   ESE_VIDEO_CODEC_UNKNOWN = 0,
   ESE_VIDEO_CODEC_H264,
@@ -75,6 +78,10 @@ extern "C" {
 ES_EXTRACTOR_API
 ESExtractor *
 es_extractor_new (const char *uri, const char *options);
+
+ES_EXTRACTOR_API
+ESExtractor *
+es_extractor_new_with_read_func (ese_read_buffer_func func, void *data, const char *options);
 
 ES_EXTRACTOR_API
 void

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -2,6 +2,7 @@ esextractor_sources = files(
   'esextractor.cpp',
   'esereader.cpp',
   'esefilereader.cpp',
+  'esedatareader.cpp',
   'esestream.cpp',
   'eseivfstream.cpp',
   'esenalstream.cpp',

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -1,6 +1,7 @@
 esextractor_sources = files(
   'esextractor.cpp',
   'esereader.cpp',
+  'esefilereader.cpp',
   'esestream.cpp',
   'eseivfstream.cpp',
   'esenalstream.cpp',

--- a/meson.build
+++ b/meson.build
@@ -24,7 +24,7 @@ subdir('tests')
 clang_format = find_program('clang-format', required: false)
 # Install clang-format pre-commit hook
 if clang_format.found()
-  run_command(python3, '-c', 'import shutil; shutil.copy("scripts/git-hooks/multi-pre-commit.hook", ".git/hooks/pre-commit")', check: false)
+  run_command(python3, '-c', 'import shutil; shutil.copy("scripts/git-hooks/pre-commit", ".git/hooks/pre-commit")', check: false)
 else
   message('clang-format not found, please install it with your package manager to enable the commit message hook')
 endif

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+# Run clang-format on all modified .cpp and .h files
+# Need to copy .clang-format in /tmp/ as the file needs to
+# be in the same folder as temporary ones.
+REPO_DIR=$( git rev-parse --show-toplevel )
+cp $REPO_DIR/.clang-format /tmp/
+for file in `git diff-index --cached --name-only HEAD --diff-filter=ACMR| grep -E '\.(cpp|h)$'` ; do
+    echo "$file"
+    nf=`git checkout-index --temp ${file} | cut -f 1`
+    newfile=`mktemp /tmp/${nf}.XXXXXX` || exit 1
+    cp $nf $newfile
+    clang-format -i $newfile
+    diff -u -p "${nf}" "${newfile}"
+    r=$?
+    rm "${newfile}"
+    rm "${nf}"
+    if [ $r != 0 ] ; then
+        ERROR_FILES="$ERROR_FILES $file"
+        echo "================================================================================================="
+        echo " Code style error in: $file                                                                      "
+        echo "================================================================================================="
+        echo ""
+    fi
+done
+# Do not forget to remove the .clang-format
+rm /tmp/.clang-format
+
+if [ -n "$ERROR_FILES" ];then
+    echo "================================================================================================="
+    echo " Code style error in:                                                                            "
+    for file in $ERROR_FILES ; do
+        echo "   $file"
+    done
+    echo "                                                                                                 "
+    echo " Please fix before committing. Don't forget to run git add before trying to commit again.        "
+    echo " If the whole file is to be committed, this should work (run from the top-level directory):      "
+    echo "   clang-format -i$ERROR_FILES ; git add$ERROR_FILES ; git commit"
+    echo "                                                                                                 "
+    echo "================================================================================================="
+    exit 1
+fi

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -12,7 +12,7 @@ esextractortestbin = executable(
 esextractortest = executable(
   'testesesuite',
   files('testsuite.cpp', 'testese.cpp'),
-  include_directories : [inc_dirs],
+  include_directories : inc_dirs,
   override_options: _override_options,
   dependencies: [libesextractor_dep]
 )

--- a/tests/testese.h
+++ b/tests/testese.h
@@ -20,6 +20,11 @@
 #include "eselogger.h"
 #include "esextractor.h"
 
-ESExtractor* create_es_extractor (const char *fileName, const char* options, uint8_t debug_level);
-int parse (ESExtractor* extractor);
-int parse_file (const char *fileName, const char* options, uint8_t debug_level);
+ESExtractor *
+create_es_extractor (const char *fileName, const char *options, uint8_t debug_level);
+int
+parse (ESExtractor *extractor);
+int
+parse_file (const char *fileName, const char *options, uint8_t debug_level);
+int
+parse_data (const char *fileName, const char *options, uint8_t debug_level);

--- a/tests/testsuite.cpp
+++ b/tests/testsuite.cpp
@@ -59,8 +59,11 @@ main (int argc, char *argv[])
 {
   int log_level = ES_LOG_LEVEL_INFO;
 
+  // NAL tests
   check_nal_file (ESE_SAMPLES_FOLDER "/Sample_10.avc", log_level, ESE_VIDEO_CODEC_H264, "h264", 22, 10);
   check_nal_file (ESE_SAMPLES_FOLDER "/Sample_10.hevc", log_level, ESE_VIDEO_CODEC_H265, "h265", 23, 10);
+  // Parse with data provider
+  assert (parse_data (ESE_SAMPLES_FOLDER "/Sample_10.avc", nullptr, log_level) == 22);
 
   // IVF tests
   check_ivf_file (ESE_SAMPLES_FOLDER "/clip-a.ivf", log_level, ESE_VIDEO_CODEC_AV1, "av1", 30);


### PR DESCRIPTION
To not rely only on file, offer a possibility to give a data provider method with format

typedef int32_t (*ese_reader_read_buffer_func) (void* opaque, unsigned char *buffer, int32_t buffer_size, int32_t offset);
